### PR TITLE
Fix all warning generated by cargo clippy, and auto format it.

### DIFF
--- a/src/algorithm/encryption/aes_ctr_128.rs
+++ b/src/algorithm/encryption/aes_ctr_128.rs
@@ -2,7 +2,7 @@ use aes::Aes128Ctr;
 use aes::cipher::{NewCipher, StreamCipher, StreamCipherSeek};
 use crate::{SshError, SshResult};
 use crate::algorithm::encryption::Encryption;
-use crate::algorithm::hash::hash::HASH;
+use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::mac::Mac;
 
 
@@ -14,7 +14,7 @@ pub struct AesCtr128 {
     pub(crate) client_key: Aes128Ctr,
     pub(crate) server_key: Aes128Ctr,
 
-    hash: HASH,
+    hash: Hash,
     mac: Box<dyn Mac>,
 }
 
@@ -26,7 +26,7 @@ impl Encryption for AesCtr128 {
         IV_SIZE
     }
 
-    fn new(hash: HASH, mac: Box<dyn Mac>) -> Self {
+    fn new(hash: Hash, mac: Box<dyn Mac>) -> Self {
         let (ck, sk) = hash.extend_key(BSIZE);
         let mut ckey = [0u8; BSIZE];
         let mut skey = [0u8; BSIZE];

--- a/src/algorithm/encryption/aes_ctr_128.rs
+++ b/src/algorithm/encryption/aes_ctr_128.rs
@@ -1,14 +1,12 @@
-use aes::Aes128Ctr;
-use aes::cipher::{NewCipher, StreamCipher, StreamCipherSeek};
-use crate::{SshError, SshResult};
 use crate::algorithm::encryption::Encryption;
 use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::mac::Mac;
-
+use crate::{SshError, SshResult};
+use aes::cipher::{NewCipher, StreamCipher, StreamCipherSeek};
+use aes::Aes128Ctr;
 
 const BSIZE: usize = 16;
 const IV_SIZE: usize = 16;
-
 
 pub struct AesCtr128 {
     pub(crate) client_key: Aes128Ctr,
@@ -48,13 +46,17 @@ impl Encryption for AesCtr128 {
             client_key: c,
             server_key: r,
             hash,
-            mac
+            mac,
         }
     }
 
     fn encrypt(&mut self, client_sequence_num: u32, buf: &mut Vec<u8>) {
         let vec = buf.clone();
-        let tag = self.mac.sign(&self.hash.ik_c_s[..self.mac.bsize()], client_sequence_num, vec.as_slice());
+        let tag = self.mac.sign(
+            &self.hash.ik_c_s[..self.mac.bsize()],
+            client_sequence_num,
+            vec.as_slice(),
+        );
         self.client_key.apply_keystream(buf);
         buf.extend(tag.as_ref())
     }
@@ -64,10 +66,14 @@ impl Encryption for AesCtr128 {
         let data = &mut buf[..(pl + 20)];
         let (d, m) = data.split_at_mut(pl);
         self.server_key.apply_keystream(d);
-        let tag = self.mac.sign(&self.hash.ik_s_c[..self.mac.bsize()], server_sequence_number, d);
+        let tag = self.mac.sign(
+            &self.hash.ik_s_c[..self.mac.bsize()],
+            server_sequence_number,
+            d,
+        );
         let t = tag.as_ref();
         if m != t {
-            return Err(SshError::from("encryption error."))
+            return Err(SshError::from("encryption error."));
         }
         Ok(d.to_vec())
     }

--- a/src/algorithm/encryption/chacha20_poly1305_openssh.rs
+++ b/src/algorithm/encryption/chacha20_poly1305_openssh.rs
@@ -1,6 +1,6 @@
 use ring::aead::chacha20_poly1305_openssh::{OpeningKey, SealingKey};
 use crate::algorithm::encryption::Encryption;
-use crate::algorithm::hash::hash::HASH;
+use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::mac::Mac;
 use crate::error::SshError;
 
@@ -22,7 +22,7 @@ impl Encryption for ChaCha20Poly1305 {
     }
 
 
-    fn new(hash: HASH, _mac: Box<dyn Mac>) -> ChaCha20Poly1305 {
+    fn new(hash: Hash, _mac: Box<dyn Mac>) -> ChaCha20Poly1305 {
         let (ck, sk) = hash.extend_key(BSIZE);
         let mut sealing_key = [0_u8; BSIZE];
         let mut opening_key = [0_u8; BSIZE];

--- a/src/algorithm/encryption/chacha20_poly1305_openssh.rs
+++ b/src/algorithm/encryption/chacha20_poly1305_openssh.rs
@@ -1,9 +1,8 @@
-use ring::aead::chacha20_poly1305_openssh::{OpeningKey, SealingKey};
 use crate::algorithm::encryption::Encryption;
 use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::mac::Mac;
 use crate::error::SshError;
-
+use ring::aead::chacha20_poly1305_openssh::{OpeningKey, SealingKey};
 
 const BSIZE: usize = 64;
 
@@ -18,9 +17,8 @@ impl Encryption for ChaCha20Poly1305 {
     }
 
     fn iv_size(&self) -> usize {
-       0
+        0
     }
-
 
     fn new(hash: Hash, _mac: Box<dyn Mac>) -> ChaCha20Poly1305 {
         let (ck, sk) = hash.extend_key(BSIZE);
@@ -31,13 +29,14 @@ impl Encryption for ChaCha20Poly1305 {
 
         ChaCha20Poly1305 {
             client_key: SealingKey::new(&sealing_key),
-            server_key: OpeningKey::new(&opening_key)
+            server_key: OpeningKey::new(&opening_key),
         }
     }
 
     fn encrypt(&mut self, sequence_number: u32, buf: &mut Vec<u8>) {
         let mut tag = [0_u8; 16];
-        self.client_key.seal_in_place(sequence_number, buf, &mut tag);
+        self.client_key
+            .seal_in_place(sequence_number, buf, &mut tag);
         buf.append(&mut tag.to_vec());
     }
 
@@ -45,24 +44,25 @@ impl Encryption for ChaCha20Poly1305 {
         let mut packet_len_slice = [0_u8; 4];
         let len = &buf[..4];
         packet_len_slice.copy_from_slice(len);
-        let packet_len_slice = self.server_key.decrypt_packet_length(sequence_number, packet_len_slice);
+        let packet_len_slice = self
+            .server_key
+            .decrypt_packet_length(sequence_number, packet_len_slice);
         let packet_len = u32::from_be_bytes(packet_len_slice);
         let (buf, tag_) = buf.split_at_mut((packet_len + 4) as usize);
         let mut tag = [0_u8; 16];
         tag.copy_from_slice(tag_);
         match self.server_key.open_in_place(sequence_number, buf, &tag) {
-            Ok(result) =>  Ok([&packet_len_slice[..], result].concat()),
-            Err(_) => Err(SshError::from("encryption error."))
+            Ok(result) => Ok([&packet_len_slice[..], result].concat()),
+            Err(_) => Err(SshError::from("encryption error.")),
         }
     }
 
     fn packet_len(&mut self, sequence_number: u32, buf: &[u8]) -> usize {
         let mut packet_len_slice = [0_u8; 4];
         packet_len_slice.copy_from_slice(&buf[..4]);
-        let packet_len_slice = self.server_key
-            .decrypt_packet_length(
-                sequence_number,
-                packet_len_slice);
+        let packet_len_slice = self
+            .server_key
+            .decrypt_packet_length(sequence_number, packet_len_slice);
         u32::from_be_bytes(packet_len_slice) as usize
     }
 

--- a/src/algorithm/encryption/mod.rs
+++ b/src/algorithm/encryption/mod.rs
@@ -1,14 +1,10 @@
-mod chacha20_poly1305_openssh;
 mod aes_ctr_128;
+mod chacha20_poly1305_openssh;
 
-pub(crate) use {
-    chacha20_poly1305_openssh::ChaCha20Poly1305,
-    aes_ctr_128::AesCtr128
-};
 use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::mac::Mac;
 use crate::SshResult;
-
+pub(crate) use {aes_ctr_128::AesCtr128, chacha20_poly1305_openssh::ChaCha20Poly1305};
 
 /// # 加密算法
 /// 在密钥交互中将协商出一种加密算法和一个密钥。当加密生效时，每个数据包的数据包长度、填
@@ -19,11 +15,12 @@ use crate::SshResult;
 /// 两个方向上的加密器必须独立运行。如果本地策略允许多种算法，系统实现必须允许独立选择每
 /// 个方向上的算法。但是，在实际使用中，推荐在两个方向上使用相同的算法。
 
-
 pub trait Encryption {
     fn bsize(&self) -> usize;
     fn iv_size(&self) -> usize;
-    fn new(hash: Hash, mac: Box<dyn Mac>) -> Self where Self: Sized;
+    fn new(hash: Hash, mac: Box<dyn Mac>) -> Self
+    where
+        Self: Sized;
     fn encrypt(&mut self, client_sequence_num: u32, buf: &mut Vec<u8>);
     fn decrypt(&mut self, sequence_number: u32, buf: &mut [u8]) -> SshResult<Vec<u8>>;
     fn packet_len(&mut self, sequence_number: u32, buf: &[u8]) -> usize;

--- a/src/algorithm/encryption/mod.rs
+++ b/src/algorithm/encryption/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use {
     chacha20_poly1305_openssh::ChaCha20Poly1305,
     aes_ctr_128::AesCtr128
 };
-use crate::algorithm::hash::hash::HASH;
+use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::mac::Mac;
 use crate::SshResult;
 
@@ -23,7 +23,7 @@ use crate::SshResult;
 pub trait Encryption {
     fn bsize(&self) -> usize;
     fn iv_size(&self) -> usize;
-    fn new(hash: HASH, mac: Box<dyn Mac>) -> Self where Self: Sized;
+    fn new(hash: Hash, mac: Box<dyn Mac>) -> Self where Self: Sized;
     fn encrypt(&mut self, client_sequence_num: u32, buf: &mut Vec<u8>);
     fn decrypt(&mut self, sequence_number: u32, buf: &mut [u8]) -> SshResult<Vec<u8>>;
     fn packet_len(&mut self, sequence_number: u32, buf: &[u8]) -> usize;

--- a/src/algorithm/hash/hash.rs
+++ b/src/algorithm/hash/hash.rs
@@ -26,7 +26,7 @@ use crate::h::H;
 
 
 
-pub struct HASH {
+pub struct Hash {
     /// IV
     pub iv_c_s          : Vec<u8>,
     pub iv_s_c          : Vec<u8>,
@@ -45,15 +45,15 @@ pub struct HASH {
 }
 
 
-impl HASH {
+impl Hash {
     pub fn new(h: H, session_id: &[u8], hash_type: HashType) -> Self {
         let k = h.k.as_slice();
         let h_ = hash::digest(&h.as_bytes(), hash_type);
         let mut keys = vec![];
         for v in constant::ALPHABET {
-            keys.push(HASH::mix(k, &h_, v, session_id, hash_type));
+            keys.push(Hash::mix(k, &h_, v, session_id, hash_type));
         }
-        HASH {
+        Hash {
             iv_c_s: keys[0].clone(),
             iv_s_c: keys[1].clone(),
 

--- a/src/algorithm/hash/hash.rs
+++ b/src/algorithm/hash/hash.rs
@@ -3,7 +3,6 @@ use crate::algorithm::hash::HashType;
 use crate::constant;
 use crate::h::H;
 
-
 /// 加密密钥必须是对一个已知值和 K 的 HASH 结果，方法如下：
 /// ○ 客户端到服务器的初始 IV：HASH(K || H || "A" || session_id)（这里 K 为 mpint
 /// 格式，"A"为 byte 格式，session_id 为原始数据（raw data）。"A"是单个字母 A，
@@ -24,26 +23,22 @@ use crate::h::H;
 /// key = K1 || K2 || K3 || ...
 /// 如果 K 的熵比 HASH 的内状态（internal state）大小要大，则该过程将造成熵的丢失。
 
-
-
 pub struct Hash {
     /// IV
-    pub iv_c_s          : Vec<u8>,
-    pub iv_s_c          : Vec<u8>,
+    pub iv_c_s: Vec<u8>,
+    pub iv_s_c: Vec<u8>,
 
     /// 数据加密的 key
-    pub ek_c_s          : Vec<u8>,
-    pub ek_s_c          : Vec<u8>,
+    pub ek_c_s: Vec<u8>,
+    pub ek_s_c: Vec<u8>,
 
     /// Hmac时候用到的 key
-    pub ik_c_s          : Vec<u8>,
-    pub ik_s_c          : Vec<u8>,
+    pub ik_c_s: Vec<u8>,
+    pub ik_s_c: Vec<u8>,
 
-    
     hash_type: HashType,
-    h: H
+    h: H,
 }
-
 
 impl Hash {
     pub fn new(h: H, session_id: &[u8], hash_type: HashType) -> Self {
@@ -64,7 +59,7 @@ impl Hash {
             ik_s_c: keys[5].clone(),
 
             hash_type,
-            h
+            h,
         }
     }
 
@@ -96,5 +91,4 @@ impl Hash {
         hash.extend(key);
         hash::digest(hash.as_slice(), self.hash_type)
     }
-
 }

--- a/src/algorithm/hash/hash_type.rs
+++ b/src/algorithm/hash/hash_type.rs
@@ -3,5 +3,5 @@
 #[derive(Copy, Clone)]
 pub enum HashType {
     SHA1,
-    SHA256
+    SHA256,
 }

--- a/src/algorithm/hash/mod.rs
+++ b/src/algorithm/hash/mod.rs
@@ -1,8 +1,6 @@
-
 #[allow(clippy::module_inception)]
 pub mod hash;
 mod hash_type;
-
 
 pub use hash_type::HashType;
 

--- a/src/algorithm/hash/mod.rs
+++ b/src/algorithm/hash/mod.rs
@@ -1,4 +1,5 @@
 
+#[allow(clippy::module_inception)]
 pub mod hash;
 mod hash_type;
 

--- a/src/algorithm/key_exchange/curve25519.rs
+++ b/src/algorithm/key_exchange/curve25519.rs
@@ -1,31 +1,28 @@
-use ring::agreement::{EphemeralPrivateKey, PublicKey, UnparsedPublicKey, X25519};
 use crate::algorithm::hash::HashType;
 use crate::algorithm::key_exchange::KeyExchange;
 use crate::error::SshError;
 use crate::SshResult;
+use ring::agreement::{EphemeralPrivateKey, PublicKey, UnparsedPublicKey, X25519};
 
 pub struct CURVE25519 {
     pub private_key: EphemeralPrivateKey,
-    pub public_key: PublicKey
+    pub public_key: PublicKey,
 }
 
 impl KeyExchange for CURVE25519 {
-
     fn new() -> SshResult<Self> {
         let rng = ring::rand::SystemRandom::new();
         let private_key = match EphemeralPrivateKey::generate(&X25519, &rng) {
             Ok(v) => v,
-            Err(_) => return Err(SshError::from("encryption error."))
+            Err(_) => return Err(SshError::from("encryption error.")),
         };
         match private_key.compute_public_key() {
-            Ok(public_key) =>
-                Ok(CURVE25519 {
+            Ok(public_key) => Ok(CURVE25519 {
                 private_key,
-                public_key
+                public_key,
             }),
-            Err(_) => Err(SshError::from("encryption error."))
+            Err(_) => Err(SshError::from("encryption error.")),
         }
-
     }
 
     fn get_public_key(&self) -> &[u8] {

--- a/src/algorithm/key_exchange/ecdh_sha2_nistp256.rs
+++ b/src/algorithm/key_exchange/ecdh_sha2_nistp256.rs
@@ -1,36 +1,33 @@
-use ring::agreement::{ECDH_P256, EphemeralPrivateKey, PublicKey, UnparsedPublicKey};
 use crate::algorithm::key_exchange::KeyExchange;
+use ring::agreement::{EphemeralPrivateKey, PublicKey, UnparsedPublicKey, ECDH_P256};
 
-use crate::{SshError, SshResult};
 use crate::algorithm::hash::HashType;
+use crate::{SshError, SshResult};
 
 pub struct EcdhP256 {
     pub private_key: EphemeralPrivateKey,
-    pub public_key: PublicKey
+    pub public_key: PublicKey,
 }
 
 impl KeyExchange for EcdhP256 {
     fn new() -> SshResult<Self> {
         let rng = ring::rand::SystemRandom::new();
-        let private_key =
-            match EphemeralPrivateKey::generate(&ECDH_P256, &rng) {
+        let private_key = match EphemeralPrivateKey::generate(&ECDH_P256, &rng) {
             Ok(v) => v,
-            Err(_) => return Err(SshError::from("encryption error."))
+            Err(_) => return Err(SshError::from("encryption error.")),
         };
         match private_key.compute_public_key() {
-            Ok(public_key) =>
-                Ok(EcdhP256 {
-                    private_key,
-                    public_key
-                }),
-            Err(_) => Err(SshError::from("encryption error."))
+            Ok(public_key) => Ok(EcdhP256 {
+                private_key,
+                public_key,
+            }),
+            Err(_) => Err(SshError::from("encryption error.")),
         }
     }
 
     fn get_public_key(&self) -> &[u8] {
         self.public_key.as_ref()
     }
-
 
     fn get_shared_secret(&self, puk: Vec<u8>) -> SshResult<Vec<u8>> {
         let mut public_key = [0u8; 65];

--- a/src/algorithm/key_exchange/mod.rs
+++ b/src/algorithm/key_exchange/mod.rs
@@ -1,41 +1,35 @@
+use crate::algorithm::hash::HashType;
+use crate::{SshError, SshResult};
 use ring::agreement;
 use ring::agreement::{EphemeralPrivateKey, UnparsedPublicKey};
-use crate::{SshError, SshResult};
-use crate::algorithm::hash::HashType;
-
 
 /// # 密钥交换方法
 ///
 /// 密钥交换方法规定如何生成用于加密和验证的一次性会话密钥，以及如何进行服务器验证。
 ///
-
-
 pub(crate) mod curve25519;
 pub(crate) mod ecdh_sha2_nistp256;
 
-
 pub trait KeyExchange: Send + Sync {
-    fn new() -> SshResult<Self> where Self: Sized;
+    fn new() -> SshResult<Self>
+    where
+        Self: Sized;
     fn get_public_key(&self) -> &[u8];
     fn get_shared_secret(&self, puk: Vec<u8>) -> SshResult<Vec<u8>>;
     fn get_hash_type(&self) -> HashType;
 }
 
-
 pub(crate) fn agree_ephemeral<B: AsRef<[u8]>>(
     private_key: EphemeralPrivateKey,
-    peer_public_key: &UnparsedPublicKey<B>)
-    -> SshResult<Vec<u8>>
-{
+    peer_public_key: &UnparsedPublicKey<B>,
+) -> SshResult<Vec<u8>> {
     match agreement::agree_ephemeral(
         private_key,
         peer_public_key,
         ring::error::Unspecified,
-        |_key_material| {
-            Ok(_key_material.to_vec())
-        },
+        |_key_material| Ok(_key_material.to_vec()),
     ) {
         Ok(o) => Ok(o),
-        Err(_) => Err(SshError::from("encryption error."))
+        Err(_) => Err(SshError::from("encryption error.")),
     }
 }

--- a/src/algorithm/key_exchange/mod.rs
+++ b/src/algorithm/key_exchange/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn agree_ephemeral<B: AsRef<[u8]>>(
 {
     match agreement::agree_ephemeral(
         private_key,
-        &peer_public_key,
+        peer_public_key,
         ring::error::Unspecified,
         |_key_material| {
             Ok(_key_material.to_vec())

--- a/src/algorithm/mac/hmac_sha1.rs
+++ b/src/algorithm/mac/hmac_sha1.rs
@@ -1,13 +1,12 @@
+use crate::algorithm::mac::Mac;
 use ring::hmac;
 use ring::hmac::{Context, Tag};
-use crate::algorithm::mac::Mac;
 
 const BSIZE: usize = 20;
 
 pub(crate) struct HMacSha1;
 
 impl Mac for HMacSha1 {
-
     fn sign(&self, ik: &[u8], sequence_num: u32, buf: &[u8]) -> Tag {
         let ik = &ik[..BSIZE];
         let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, ik);
@@ -17,7 +16,10 @@ impl Mac for HMacSha1 {
         c.sign()
     }
 
-    fn new() -> Self where Self: Sized {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
         HMacSha1
     }
 

--- a/src/algorithm/mac/mod.rs
+++ b/src/algorithm/mac/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod hmac_sha1;
 
 pub trait Mac {
     fn sign(&self, ik: &[u8], sequence_num: u32, buf: &[u8]) -> Tag;
-    fn new() -> Self where Self: Sized;
+    fn new() -> Self
+    where
+        Self: Sized;
     fn bsize(&self) -> usize;
 }

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) mod key_exchange;
-pub(crate) mod hash;
-pub(crate) mod public_key;
 pub(crate) mod encryption;
+pub(crate) mod hash;
+pub(crate) mod key_exchange;
 pub(crate) mod mac;
+pub(crate) mod public_key;

--- a/src/algorithm/public_key/ed25519.rs
+++ b/src/algorithm/public_key/ed25519.rs
@@ -1,12 +1,15 @@
-use ring::signature;
 use crate::algorithm::public_key::PublicKey;
 use crate::data::Data;
 use crate::SshError;
+use ring::signature;
 
 pub struct Ed25519;
 
 impl PublicKey for Ed25519 {
-    fn new() -> Self where Self: Sized {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
         Self
     }
 
@@ -14,8 +17,7 @@ impl PublicKey for Ed25519 {
         let mut data = Data::from(ks[4..].to_vec());
         data.get_u8s();
         let host_key = data.get_u8s();
-        let pub_key =
-            signature::UnparsedPublicKey::new(&signature::ED25519, host_key);
+        let pub_key = signature::UnparsedPublicKey::new(&signature::ED25519, host_key);
         Ok(pub_key.verify(message, sig).is_ok())
     }
 }

--- a/src/algorithm/public_key/mod.rs
+++ b/src/algorithm/public_key/mod.rs
@@ -3,16 +3,15 @@ use crate::SshError;
 mod ed25519;
 mod rsa;
 
-
-pub(crate) use ed25519::Ed25519;
 pub(crate) use self::rsa::Rsa;
-
+pub(crate) use ed25519::Ed25519;
 
 /// # 公钥算法
 /// 主要用于对服务端签名的验证
 
-
 pub trait PublicKey: Send + Sync {
-    fn new() -> Self where Self: Sized;
+    fn new() -> Self
+    where
+        Self: Sized;
     fn verify_signature(&self, ks: &[u8], message: &[u8], sig: &[u8]) -> Result<bool, SshError>;
 }

--- a/src/algorithm/public_key/mod.rs
+++ b/src/algorithm/public_key/mod.rs
@@ -5,7 +5,7 @@ mod rsa;
 
 
 pub(crate) use ed25519::Ed25519;
-pub(crate) use self::rsa::RSA;
+pub(crate) use self::rsa::Rsa;
 
 
 /// # 公钥算法

--- a/src/algorithm/public_key/rsa.rs
+++ b/src/algorithm/public_key/rsa.rs
@@ -4,9 +4,9 @@ use crate::data::Data;
 use crate::SshError;
 
 
-pub struct RSA;
+pub struct Rsa;
 
-impl PubK for RSA {
+impl PubK for Rsa {
     fn new() -> Self where Self: Sized {
         Self
     }

--- a/src/algorithm/public_key/rsa.rs
+++ b/src/algorithm/public_key/rsa.rs
@@ -1,18 +1,19 @@
-use rsa::PublicKey;
 use crate::algorithm::public_key::PublicKey as PubK;
 use crate::data::Data;
 use crate::SshError;
-
+use rsa::PublicKey;
 
 pub struct Rsa;
 
 impl PubK for Rsa {
-    fn new() -> Self where Self: Sized {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
         Self
     }
 
     fn verify_signature(&self, ks: &[u8], message: &[u8], sig: &[u8]) -> Result<bool, SshError> {
-
         let mut data = Data::from((&ks[4..]).to_vec());
         data.get_u8s();
 
@@ -20,7 +21,7 @@ impl PubK for Rsa {
         let n = rsa::BigUint::from_bytes_be(data.get_u8s().as_slice());
         let public_key = rsa::RsaPublicKey::new(n, e).unwrap();
         let scheme = rsa::PaddingScheme::PKCS1v15Sign {
-            hash: Some(rsa::Hash::SHA1)
+            hash: Some(rsa::Hash::SHA1),
         };
 
         let digest = ring::digest::digest(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY, message);

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,13 +1,13 @@
-use std::ops::{Deref, DerefMut};
-use crate::constant::{ssh_msg_code};
-use crate::error::{SshError, SshResult};
-use crate::data::Data;
-use crate::slog::log;
 use crate::channel_exec::ChannelExec;
 use crate::channel_scp::ChannelScp;
 use crate::channel_shell::ChannelShell;
-use crate::Session;
+use crate::constant::ssh_msg_code;
+use crate::data::Data;
+use crate::error::{SshError, SshResult};
+use crate::slog::log;
 use crate::window_size::WindowSize;
+use crate::Session;
+use std::ops::{Deref, DerefMut};
 
 pub struct Channel {
     pub(crate) remote_close: bool,
@@ -54,11 +54,13 @@ impl Channel {
                 let rws = result.get_u32();
                 self.window_size.add_remote_window_size(rws);
                 self.window_size.add_remote_max_window_size(rws);
-            },
+            }
             ssh_msg_code::SSH_MSG_CHANNEL_EOF => {}
             ssh_msg_code::SSH_MSG_CHANNEL_REQUEST => {}
             ssh_msg_code::SSH_MSG_CHANNEL_SUCCESS => {}
-            ssh_msg_code::SSH_MSG_CHANNEL_FAILURE => return Err(SshError::from("channel failure.")),
+            ssh_msg_code::SSH_MSG_CHANNEL_FAILURE => {
+                return Err(SshError::from("channel failure."))
+            }
             ssh_msg_code::SSH_MSG_CHANNEL_CLOSE => {
                 let cc = result.get_u32();
                 if cc == self.client_channel_no {
@@ -93,7 +95,9 @@ impl Channel {
     }
 
     fn send_close(&mut self) -> SshResult<()> {
-        if self.local_close { return Ok(()); }
+        if self.local_close {
+            return Ok(());
+        }
         let mut data = Data::new();
         data.put_u8(ssh_msg_code::SSH_MSG_CHANNEL_CLOSE)
             .put_u32(self.server_channel_no);
@@ -104,24 +108,26 @@ impl Channel {
     }
 
     fn receive_close(&mut self) -> SshResult<()> {
-        if self.remote_close { return Ok(()); }
+        if self.remote_close {
+            return Ok(());
+        }
         loop {
             // close 时不消耗窗口空间
-            let results = {
-                self.get_session_mut().client.as_mut().unwrap().read()
-            }?;
+            let results = { self.get_session_mut().client.as_mut().unwrap().read() }?;
             for mut result in results {
-                if result.is_empty() { continue }
+                if result.is_empty() {
+                    continue;
+                }
                 let message_code = result.get_u8();
                 match message_code {
                     ssh_msg_code::SSH_MSG_CHANNEL_CLOSE => {
                         let cc = result.get_u32();
                         if cc == self.client_channel_no {
                             self.remote_close = true;
-                            return Ok(())
+                            return Ok(());
                         }
                     }
-                    _ => self.other(message_code, result)?
+                    _ => self.other(message_code, result)?,
                 }
             }
         }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -73,17 +73,17 @@ impl Channel {
 
     pub fn open_shell(self) -> SshResult<ChannelShell> {
         log::info!("shell opened.");
-        return ChannelShell::open(self)
+        ChannelShell::open(self)
     }
 
     pub fn open_exec(self) -> SshResult<ChannelExec> {
         log::info!("exec opened.");
-        return Ok(ChannelExec::open(self))
+        Ok(ChannelExec::open(self))
     }
 
     pub fn open_scp(self) -> SshResult<ChannelScp> {
         log::info!("scp opened.");
-        return Ok(ChannelScp::open(self))
+        Ok(ChannelScp::open(self))
     }
 
     pub fn close(&mut self) -> SshResult<()> {
@@ -127,6 +127,7 @@ impl Channel {
         }
     }
 
+    #[allow(clippy::mut_from_ref)]
     pub(crate) fn get_session_mut(&self) -> &mut Session {
         unsafe { &mut *self.session }
     }

--- a/src/channel_scp.rs
+++ b/src/channel_scp.rs
@@ -1,11 +1,9 @@
-use std::borrow::BorrowMut;
-use std::path::{Path, PathBuf};
 use crate::constant::{scp, ssh_msg_code, ssh_str};
 use crate::data::Data;
-use crate::error::{SshResult, SshError};
+use crate::error::{SshError, SshResult};
 use crate::Channel;
-
-
+use std::borrow::BorrowMut;
+use std::path::{Path, PathBuf};
 
 pub struct ChannelScp {
     pub(crate) channel: Channel,
@@ -13,15 +11,12 @@ pub struct ChannelScp {
 }
 
 impl ChannelScp {
-
-
     pub(crate) fn open(channel: Channel) -> Self {
         ChannelScp {
             channel,
             local_path: Default::default(),
         }
     }
-
 
     pub(crate) fn send_str(&mut self, cmd: &str) -> SshResult<()> {
         self.send_bytes(cmd.as_bytes())
@@ -37,15 +32,25 @@ impl ChannelScp {
             .put_u32(self.channel.server_channel_no)
             .put_u8s(bytes);
         let session = unsafe { &mut *self.channel.session };
-        session.client.as_mut().unwrap().write_data(data, Some(self.channel.window_size.borrow_mut()))
+        session
+            .client
+            .as_mut()
+            .unwrap()
+            .write_data(data, Some(self.channel.window_size.borrow_mut()))
     }
 
     pub(crate) fn read_data(&mut self) -> SshResult<Vec<u8>> {
         let mut vec = vec![];
         loop {
-            if !vec.is_empty() { break }
+            if !vec.is_empty() {
+                break;
+            }
             let session = unsafe { &mut *self.channel.session };
-            let results = session.client.as_mut().unwrap().read_data(Some(self.channel.window_size.borrow_mut()))?;
+            let results = session
+                .client
+                .as_mut()
+                .unwrap()
+                .read_data(Some(self.channel.window_size.borrow_mut()))?;
             for mut result in results {
                 let message_code = result.get_u8();
                 match message_code {
@@ -60,10 +65,10 @@ impl ChannelScp {
                         if cc == self.channel.client_channel_no {
                             self.channel.remote_close = true;
                             self.channel.close()?;
-                            return Ok(vec)
+                            return Ok(vec);
                         }
-                    },
-                    _ => self.channel.other(message_code, result)?
+                    }
+                    _ => self.channel.other(message_code, result)?,
                 }
             }
         }
@@ -77,7 +82,12 @@ impl ChannelScp {
             .put_str(ssh_str::EXEC)
             .put_u8(true as u8)
             .put_str(command);
-        self.channel.get_session_mut().client.as_mut().unwrap().write(data)
+        self.channel
+            .get_session_mut()
+            .client
+            .as_mut()
+            .unwrap()
+            .write(data)
     }
 
     pub(crate) fn command_init(&self, remote_path: &str, arg: &str) -> String {
@@ -93,14 +103,12 @@ impl ChannelScp {
     }
 }
 
-
 pub(crate) fn check_path(path: &Path) -> SshResult<()> {
     if path.to_str().is_none() {
-        return Err(SshError::from("path is null."))
+        return Err(SshError::from("path is null."));
     }
     Ok(())
 }
-
 
 pub struct ScpFile {
     pub(crate) modify_time: i64,
@@ -123,5 +131,3 @@ impl ScpFile {
         }
     }
 }
-
-

--- a/src/channel_scp.rs
+++ b/src/channel_scp.rs
@@ -95,7 +95,7 @@ impl ChannelScp {
 
 
 pub(crate) fn check_path(path: &Path) -> SshResult<()> {
-    if let None = path.to_str() {
+    if path.to_str().is_none() {
         return Err(SshError::from("path is null."))
     }
     Ok(())

--- a/src/channel_scp_u.rs
+++ b/src/channel_scp_u.rs
@@ -100,7 +100,7 @@ impl ChannelScp {
         loop {
             let mut s = [0u8; 20480];
             let i = file.read(&mut s)?;
-            count = count + i;
+            count += i;
             self.send_bytes(&s[..i])?;
             if count == scp_file.size as usize {
                 self.send_bytes(&[0])?;
@@ -111,7 +111,7 @@ impl ChannelScp {
 
         log::debug!("file: [{}] upload completed.", scp_file.name);
 
-        return Ok(())
+        Ok(())
     }
 
     fn send_dir(&mut self, scp_file: &ScpFile) -> SshResult<()> {
@@ -124,7 +124,7 @@ impl ChannelScp {
 
         log::debug!("dir: [{}] upload completed.", scp_file.name);
 
-        return Ok(())
+        Ok(())
     }
 
 
@@ -160,7 +160,7 @@ impl ChannelScp {
 
     fn get_end(&mut self) -> SshResult<()> {
         let vec = self.read_data()?;
-        match *&vec[0] {
+        match vec[0] {
             scp::END => Ok(()),
             // error
             scp::ERR | scp::FATAL_ERR => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,10 @@
+use crate::algorithm::encryption::Encryption;
+use crate::config::Config;
+use crate::error::{SshError, SshResult};
+use crate::timeout::Timeout;
 use std::io;
 use std::net::{Shutdown, TcpStream, ToSocketAddrs};
 use std::ops::{Deref, DerefMut};
-use crate::algorithm::encryption::Encryption;
-use crate::error::{SshError, SshResult};
-use crate::timeout::Timeout;
-use crate::config::Config;
-
 
 pub struct Client {
     pub(crate) stream: TcpStream,
@@ -19,11 +18,10 @@ pub struct Client {
 #[derive(Clone)]
 pub(crate) struct Sequence {
     pub(crate) client_sequence_num: u32,
-    pub(crate) server_sequence_num: u32
+    pub(crate) server_sequence_num: u32,
 }
 
 impl Sequence {
-
     pub(crate) fn client_auto_increment(&mut self) {
         if self.client_sequence_num == u32::MAX {
             self.client_sequence_num = 0;
@@ -46,21 +44,19 @@ impl Client {
                 // default nonblocking
                 stream.set_nonblocking(true).unwrap();
 
-                Ok(
-                    Client{
-                        stream,
-                        sequence: Sequence {
-                            client_sequence_num: 0,
-                            server_sequence_num: 0
-                        },
-                        timeout: Timeout::new(timeout_sec),
-                        encryption: None,
-                        is_encryption: false,
-                        session_id: vec![]
-                    }
-                )
+                Ok(Client {
+                    stream,
+                    sequence: Sequence {
+                        client_sequence_num: 0,
+                        server_sequence_num: 0,
+                    },
+                    timeout: Timeout::new(timeout_sec),
+                    encryption: None,
+                    is_encryption: false,
+                    session_id: vec![],
+                })
             }
-            Err(e) => Err(SshError::from(e))
+            Err(e) => Err(SshError::from(e)),
         }
     }
 
@@ -85,14 +81,13 @@ impl Client {
     pub(crate) fn close(&mut self) -> Result<(), SshError> {
         match self.stream.shutdown(Shutdown::Both) {
             Ok(o) => Ok(o),
-            Err(e) => Err(SshError::from(e))
+            Err(e) => Err(SshError::from(e)),
         }
     }
 
     pub(crate) fn is_would_block(e: &io::Error) -> bool {
         e.kind() == io::ErrorKind::WouldBlock
     }
-
 }
 
 impl Deref for Client {

--- a/src/client_r.rs
+++ b/src/client_r.rs
@@ -32,7 +32,7 @@ impl Client {
         let mut result = vec![0; size::BUF_SIZE as usize];
         let len = match self.stream.read(&mut result) {
             Ok(len) => {
-                if len <= 0 {
+                if len == 0 {
                     return Ok(results)
                 }
 
@@ -104,7 +104,7 @@ impl Client {
                 v.process_local_window_size(data.as_slice(), self)?
             }
             results.push(data);
-            if remaining.len() <= 0 {
+            if remaining.is_empty() {
                 break;
             }
             result = remaining.to_vec();

--- a/src/client_r.rs
+++ b/src/client_r.rs
@@ -1,11 +1,11 @@
-use std::io;
-use std::io::Read;
 use crate::client::Client;
-use crate::data::Data;
-use crate::{SshError, SshResult};
 use crate::constant::size;
+use crate::data::Data;
 use crate::packet::Packet;
 use crate::window_size::WindowSize;
+use crate::{SshError, SshResult};
+use std::io;
+use std::io::Read;
 
 impl Client {
     /// 发送客户端版本
@@ -13,8 +13,8 @@ impl Client {
         let mut v = [0_u8; 128];
         loop {
             match self.stream.read(&mut v) {
-                Ok(i) => { return (&v[..i]).to_vec() }
-                Err(_) => continue
+                Ok(i) => return (&v[..i]).to_vec(),
+                Err(_) => continue,
             };
         }
     }
@@ -33,7 +33,7 @@ impl Client {
         let len = match self.stream.read(&mut result) {
             Ok(len) => {
                 if len == 0 {
-                    return Ok(results)
+                    return Ok(results);
                 }
 
                 // 从服务段正常读取到数据的话
@@ -41,12 +41,12 @@ impl Client {
                 self.timeout.renew();
 
                 len
-            },
+            }
             Err(e) => {
                 if Client::is_would_block(&e) {
-                    return Ok(results)
+                    return Ok(results);
                 }
-                return Err(SshError::from(e))
+                return Err(SshError::from(e));
             }
         };
 
@@ -54,7 +54,7 @@ impl Client {
         // 处理未加密数据
         match self.is_encryption {
             true => self.process_data_encrypt(result, &mut results, lws)?,
-            false => self.process_data(result, &mut results)
+            false => self.process_data(result, &mut results),
         }
         Ok(results)
     }
@@ -77,26 +77,32 @@ impl Client {
         results.push(data);
     }
 
-    pub fn process_data_encrypt(&mut self,
-                                mut result: Vec<u8>,
-                                results: &mut Vec<Data>,
-                                mut lws: Option<&mut WindowSize>
-    ) -> SshResult<()>
-    {
+    pub fn process_data_encrypt(
+        &mut self,
+        mut result: Vec<u8>,
+        results: &mut Vec<Data>,
+        mut lws: Option<&mut WindowSize>,
+    ) -> SshResult<()> {
         loop {
             self.sequence.server_auto_increment();
             if result.len() < 4 {
                 self.check_result_len(&mut result)?;
             }
             let data_len = {
-                self.encryption.as_mut().unwrap().data_len(self.sequence.server_sequence_num, result.as_slice())
+                self.encryption
+                    .as_mut()
+                    .unwrap()
+                    .data_len(self.sequence.server_sequence_num, result.as_slice())
             };
             if result.len() < data_len {
                 self.get_encrypt_data(&mut result, data_len)?;
             }
             let (this, remaining) = result.split_at_mut(data_len);
             let decryption_result = {
-                self.encryption.as_mut().unwrap().decrypt(self.sequence.server_sequence_num, &mut this.to_vec())
+                self.encryption
+                    .as_mut()
+                    .unwrap()
+                    .decrypt(self.sequence.server_sequence_num, &mut this.to_vec())
             }?;
             let data = Packet::from(decryption_result).unpacking();
             // 判断是否需要修改窗口大小
@@ -114,7 +120,6 @@ impl Client {
 
     fn get_encrypt_data(&mut self, result: &mut Vec<u8>, data_len: usize) -> SshResult<()> {
         loop {
-
             self.timeout.is_timeout()?;
 
             let mut buf = vec![0; data_len - result.len()];
@@ -126,14 +131,14 @@ impl Client {
                         result.extend(buf);
                     }
                     if result.len() >= data_len {
-                        return Ok(())
+                        return Ok(());
                     }
-                },
+                }
                 Err(e) => {
                     if e.kind() == io::ErrorKind::WouldBlock {
                         continue;
                     }
-                    return Err(SshError::from(e))
+                    return Err(SshError::from(e));
                 }
             };
         }
@@ -141,7 +146,6 @@ impl Client {
 
     fn check_result_len(&mut self, result: &mut Vec<u8>) -> SshResult<usize> {
         loop {
-
             self.timeout.is_timeout()?;
 
             let mut buf = vec![0; size::BUF_SIZE as usize];
@@ -154,14 +158,14 @@ impl Client {
                     }
 
                     if result.len() >= 4 {
-                        return Ok(len)
+                        return Ok(len);
                     }
-                },
+                }
                 Err(e) => {
                     if e.kind() == io::ErrorKind::WouldBlock {
                         continue;
                     }
-                    return Err(SshError::from(e))
+                    return Err(SshError::from(e));
                 }
             };
         }

--- a/src/client_w.rs
+++ b/src/client_w.rs
@@ -5,7 +5,6 @@ use crate::window_size::WindowSize;
 use crate::{SshError, SshResult};
 use std::io::Write;
 
-
 impl Client {
     /// 发送客户端版本
     pub(crate) fn write_version(&mut self, buf: &[u8]) -> SshResult<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,13 @@ use crate::data::Data;
 use crate::slog::log;
 use crate::{SshError, SshResult};
 use crate::algorithm::encryption::{AesCtr128, ChaCha20Poly1305, Encryption};
-use crate::algorithm::hash::hash::HASH;
+use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::key_exchange::curve25519::CURVE25519;
 use crate::algorithm::key_exchange::ecdh_sha2_nistp256::EcdhP256;
 use crate::algorithm::key_exchange::KeyExchange;
 use crate::algorithm::mac::hmac_sha1::HMacSha1;
 use crate::algorithm::mac::Mac;
-use crate::algorithm::public_key::{Ed25519, PublicKey, RSA};
+use crate::algorithm::public_key::{Ed25519, PublicKey, Rsa};
 use crate::user_info::UserInfo;
 
 
@@ -97,7 +97,7 @@ impl AlgorithmConfig {
     /// 目前支持:
     ///     1. chacha20-poly1305@openssh.com
     ///     2. aes128-ctr
-    pub fn matching_encryption_algorithm(&self, hash: HASH, mac: Box<dyn Mac>) -> SshResult<Box<dyn Encryption>> {
+    pub fn matching_encryption_algorithm(&self, hash: Hash, mac: Box<dyn Mac>) -> SshResult<Box<dyn Encryption>> {
         // 目前是加密和解密使用一个算法
         // 所以直接取一个算法为准
         let encryption_algorithm: String = get_algorithm(
@@ -131,7 +131,7 @@ impl AlgorithmConfig {
         );
         match public_key_algorithm.as_str() {
             algorithms::PUBLIC_KEY_ED25519 => Ok(Box::new(Ed25519::new())),
-            algorithms::PUBLIC_KEY_RSA => Ok(Box::new(RSA::new())),
+            algorithms::PUBLIC_KEY_RSA => Ok(Box::new(Rsa::new())),
             _ => {
                 log::error!("description the signature algorithm fails to match, \
                 algorithms supported by the server: {},\
@@ -170,13 +170,13 @@ impl AlgorithmConfig {
 
 }
 
-fn get_algorithm(c_algorithm: &Vec<String>, s_algorithm: &Vec<String>) -> String {
+fn get_algorithm(c_algorithm: &Vec<String>, s_algorithm: &[String]) -> String {
     for x in c_algorithm {
         if s_algorithm.contains(x) {
             return x.clone()
         }
     }
-    return String::new();
+    String::new()
 }
 
 #[derive(Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,3 @@
-use crate::constant::{algorithms, CLIENT_VERSION};
-use crate::data::Data;
-use crate::slog::log;
-use crate::{SshError, SshResult};
 use crate::algorithm::encryption::{AesCtr128, ChaCha20Poly1305, Encryption};
 use crate::algorithm::hash::hash::Hash;
 use crate::algorithm::key_exchange::curve25519::CURVE25519;
@@ -10,8 +6,11 @@ use crate::algorithm::key_exchange::KeyExchange;
 use crate::algorithm::mac::hmac_sha1::HMacSha1;
 use crate::algorithm::mac::Mac;
 use crate::algorithm::public_key::{Ed25519, PublicKey, Rsa};
+use crate::constant::{algorithms, CLIENT_VERSION};
+use crate::data::Data;
+use crate::slog::log;
 use crate::user_info::UserInfo;
-
+use crate::{SshError, SshResult};
 
 pub struct Config {
     pub auth: UserInfo,
@@ -24,12 +23,10 @@ impl Config {
         Config {
             auth: user_info,
             version: VersionConfig::new(),
-            algorithm: AlgorithmConfig::new()
+            algorithm: AlgorithmConfig::new(),
         }
     }
 }
-
-
 
 #[derive(Clone)]
 pub struct VersionConfig {
@@ -40,18 +37,19 @@ impl VersionConfig {
     pub fn new() -> Self {
         VersionConfig {
             client_version: CLIENT_VERSION.to_string(),
-            server_version: String::new()
+            server_version: String::new(),
         }
     }
     pub fn validation(&self) -> SshResult<()> {
         if !self.server_version.contains("SSH-2.0") {
             log::error!("error in version negotiation, version mismatch.");
-            return Err(SshError::from("error in version negotiation, version mismatch."))
+            return Err(SshError::from(
+                "error in version negotiation, version mismatch.",
+            ));
         }
-       Ok(())
+        Ok(())
     }
 }
-
 
 #[derive(Clone)]
 pub struct AlgorithmConfig {
@@ -62,10 +60,9 @@ impl AlgorithmConfig {
     pub fn new() -> Self {
         AlgorithmConfig {
             client_algorithm: AlgorithmList::client_algorithm(),
-            server_algorithm: AlgorithmList::new()
+            server_algorithm: AlgorithmList::new(),
         }
     }
-
 
     /// 匹配合适的mac算法
     /// 目前支持：
@@ -75,13 +72,14 @@ impl AlgorithmConfig {
         // 所以直接取一个算法为准
         let mac_algorithm: String = get_algorithm(
             &self.client_algorithm.c_mac_algorithm.0,
-            &self.server_algorithm.c_mac_algorithm.0
+            &self.server_algorithm.c_mac_algorithm.0,
         );
 
         match mac_algorithm.as_str() {
             algorithms::MAC_HMAC_SHA1 => Ok(Box::new(HMacSha1::new())),
             _ => {
-                log::error!("description the mac algorithm fails to match, \
+                log::error!(
+                    "description the mac algorithm fails to match, \
                 algorithms supported by the server: {},\
                 algorithms supported by the client: {}",
                     self.server_algorithm.c_mac_algorithm.to_string(),
@@ -92,23 +90,29 @@ impl AlgorithmConfig {
         }
     }
 
-
     /// 匹配合适的加密算法
     /// 目前支持:
     ///     1. chacha20-poly1305@openssh.com
     ///     2. aes128-ctr
-    pub fn matching_encryption_algorithm(&self, hash: Hash, mac: Box<dyn Mac>) -> SshResult<Box<dyn Encryption>> {
+    pub fn matching_encryption_algorithm(
+        &self,
+        hash: Hash,
+        mac: Box<dyn Mac>,
+    ) -> SshResult<Box<dyn Encryption>> {
         // 目前是加密和解密使用一个算法
         // 所以直接取一个算法为准
         let encryption_algorithm: String = get_algorithm(
             &self.client_algorithm.c_encryption_algorithm.0,
-            &self.server_algorithm.c_encryption_algorithm.0
+            &self.server_algorithm.c_encryption_algorithm.0,
         );
         match encryption_algorithm.as_str() {
-            algorithms::ENCRYPTION_CHACHA20_POLY1305_OPENSSH => Ok(Box::new(ChaCha20Poly1305::new(hash, mac))),
+            algorithms::ENCRYPTION_CHACHA20_POLY1305_OPENSSH => {
+                Ok(Box::new(ChaCha20Poly1305::new(hash, mac)))
+            }
             algorithms::ENCRYPTION_AES128_CTR => Ok(Box::new(AesCtr128::new(hash, mac))),
             _ => {
-                log::error!("description the encryption algorithm fails to match, \
+                log::error!(
+                    "description the encryption algorithm fails to match, \
                 algorithms supported by the server: {},\
                 algorithms supported by the client: {}",
                     self.server_algorithm.c_encryption_algorithm.to_string(),
@@ -117,7 +121,6 @@ impl AlgorithmConfig {
                 Err(SshError::from("key exchange error."))
             }
         }
-
     }
 
     /// 匹配合适的公钥签名算法
@@ -127,13 +130,14 @@ impl AlgorithmConfig {
     pub fn matching_public_key_algorithm(&self) -> SshResult<Box<dyn PublicKey>> {
         let public_key_algorithm: String = get_algorithm(
             &self.client_algorithm.public_key_algorithm.0,
-            &self.server_algorithm.public_key_algorithm.0
+            &self.server_algorithm.public_key_algorithm.0,
         );
         match public_key_algorithm.as_str() {
             algorithms::PUBLIC_KEY_ED25519 => Ok(Box::new(Ed25519::new())),
             algorithms::PUBLIC_KEY_RSA => Ok(Box::new(Rsa::new())),
             _ => {
-                log::error!("description the signature algorithm fails to match, \
+                log::error!(
+                    "description the signature algorithm fails to match, \
                 algorithms supported by the server: {},\
                 algorithms supported by the client: {}",
                     self.server_algorithm.public_key_algorithm.to_string(),
@@ -151,13 +155,14 @@ impl AlgorithmConfig {
     pub fn matching_key_exchange_algorithm(&self) -> SshResult<Box<dyn KeyExchange>> {
         let key_exchange_algorithm: String = get_algorithm(
             &self.client_algorithm.key_exchange_algorithm.0,
-            &self.server_algorithm.key_exchange_algorithm.0
+            &self.server_algorithm.key_exchange_algorithm.0,
         );
         match key_exchange_algorithm.as_str() {
             algorithms::DH_CURVE25519_SHA256 => Ok(Box::new(CURVE25519::new()?)),
             algorithms::DH_ECDH_SHA2_NISTP256 => Ok(Box::new(EcdhP256::new()?)),
             _ => {
-                log::error!("description the DH algorithm fails to match, \
+                log::error!(
+                    "description the DH algorithm fails to match, \
                 algorithms supported by the server: {},\
                 algorithms supported by the client: {}",
                     self.server_algorithm.key_exchange_algorithm.to_string(),
@@ -167,13 +172,12 @@ impl AlgorithmConfig {
             }
         }
     }
-
 }
 
 fn get_algorithm(c_algorithm: &Vec<String>, s_algorithm: &[String]) -> String {
     for x in c_algorithm {
         if s_algorithm.contains(x) {
-            return x.clone()
+            return x.clone();
         }
     }
     String::new()
@@ -200,7 +204,7 @@ impl AlgorithmList {
             c_mac_algorithm: MacAlgorithm(vec![]),
             s_mac_algorithm: MacAlgorithm(vec![]),
             c_compression_algorithm: CompressionAlgorithm(vec![]),
-            s_compression_algorithm: CompressionAlgorithm(vec![])
+            s_compression_algorithm: CompressionAlgorithm(vec![]),
         }
     }
 
@@ -213,7 +217,7 @@ impl AlgorithmList {
             c_mac_algorithm: MacAlgorithm::get_client(),
             s_mac_algorithm: MacAlgorithm::get_client(),
             c_compression_algorithm: CompressionAlgorithm::get_client(),
-            s_compression_algorithm: CompressionAlgorithm::get_client()
+            s_compression_algorithm: CompressionAlgorithm::get_client(),
         }
     }
 
@@ -233,7 +237,8 @@ impl AlgorithmList {
 
 impl ToString for AlgorithmList {
     fn to_string(&self) -> String {
-        format!("\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"",
+        format!(
+            "\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"",
             self.key_exchange_algorithm.to_string().as_str(),
             self.public_key_algorithm.to_string().as_str(),
             self.c_encryption_algorithm.to_string().as_str(),
@@ -246,17 +251,14 @@ impl ToString for AlgorithmList {
     }
 }
 
-
 #[derive(Clone)]
 pub struct KeyExchangeAlgorithm(pub Vec<String>);
 impl KeyExchangeAlgorithm {
     pub fn get_client() -> Self {
-        KeyExchangeAlgorithm(
-            vec![
-                algorithms::DH_CURVE25519_SHA256.to_string(),
-                algorithms::DH_ECDH_SHA2_NISTP256.to_string()
-            ]
-        )
+        KeyExchangeAlgorithm(vec![
+            algorithms::DH_CURVE25519_SHA256.to_string(),
+            algorithms::DH_ECDH_SHA2_NISTP256.to_string(),
+        ])
     }
 }
 
@@ -266,17 +268,14 @@ impl ToString for KeyExchangeAlgorithm {
     }
 }
 
-
 #[derive(Clone)]
 pub struct PublicKeyAlgorithm(pub Vec<String>);
 impl PublicKeyAlgorithm {
     pub fn get_client() -> Self {
-        PublicKeyAlgorithm(
-            vec![
-                algorithms::PUBLIC_KEY_ED25519.to_string(),
-                algorithms::PUBLIC_KEY_RSA.to_string()
-            ]
-        )
+        PublicKeyAlgorithm(vec![
+            algorithms::PUBLIC_KEY_ED25519.to_string(),
+            algorithms::PUBLIC_KEY_RSA.to_string(),
+        ])
     }
 }
 
@@ -290,12 +289,10 @@ impl ToString for PublicKeyAlgorithm {
 pub struct EncryptionAlgorithm(pub Vec<String>);
 impl EncryptionAlgorithm {
     pub fn get_client() -> Self {
-        EncryptionAlgorithm(
-            vec![
-                algorithms::ENCRYPTION_CHACHA20_POLY1305_OPENSSH.to_string(),
-                algorithms::ENCRYPTION_AES128_CTR.to_string(),
-            ]
-        )
+        EncryptionAlgorithm(vec![
+            algorithms::ENCRYPTION_CHACHA20_POLY1305_OPENSSH.to_string(),
+            algorithms::ENCRYPTION_AES128_CTR.to_string(),
+        ])
     }
 }
 impl ToString for EncryptionAlgorithm {
@@ -308,11 +305,7 @@ impl ToString for EncryptionAlgorithm {
 pub struct MacAlgorithm(pub Vec<String>);
 impl MacAlgorithm {
     pub fn get_client() -> Self {
-        MacAlgorithm(
-            vec![
-                algorithms::MAC_HMAC_SHA1.to_string(),
-            ]
-        )
+        MacAlgorithm(vec![algorithms::MAC_HMAC_SHA1.to_string()])
     }
 }
 impl ToString for MacAlgorithm {
@@ -321,16 +314,11 @@ impl ToString for MacAlgorithm {
     }
 }
 
-
 #[derive(Clone)]
 pub struct CompressionAlgorithm(pub Vec<String>);
 impl CompressionAlgorithm {
     pub fn get_client() -> Self {
-        CompressionAlgorithm(
-            vec![
-                algorithms::COMPRESSION_ALGORITHMS.to_string(),
-            ]
-        )
+        CompressionAlgorithm(vec![algorithms::COMPRESSION_ALGORITHMS.to_string()])
     }
 }
 impl ToString for CompressionAlgorithm {
@@ -339,14 +327,15 @@ impl ToString for CompressionAlgorithm {
     }
 }
 
-
 fn to_string(v: &[String]) -> String {
     let mut s = String::new();
-    if v.is_empty() { return s }
+    if v.is_empty() {
+        return s;
+    }
     for (i, val) in v.iter().enumerate() {
         if i == 0 {
             s.push_str(val);
-            continue
+            continue;
         }
         s.push_str(format!(",{}", val).as_str());
     }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,39 +1,39 @@
 
 /// 客户端版本
-pub const CLIENT_VERSION            :&'static str = "SSH-2.0-SSH_RS-0.2.1";
+pub const CLIENT_VERSION            :&str = "SSH-2.0-SSH_RS-0.2.1";
 
 
 /// ssh通讯时用到的常量字符串
 #[allow(dead_code)]
 pub mod ssh_str {
     /// 准备认证
-    pub const SSH_USERAUTH              :&'static str = "ssh-userauth";
+    pub const SSH_USERAUTH              :&str = "ssh-userauth";
     /// 开始认证
-    pub const SSH_CONNECTION            :&'static str = "ssh-connection";
+    pub const SSH_CONNECTION            :&str = "ssh-connection";
     /// 公钥验证方式
-    pub const PUBLIC_KEY                :&'static str = "publickey";
+    pub const PUBLIC_KEY                :&str = "publickey";
     /// 密码认证方式
-    pub const PASSWORD                  :&'static str = "password";
+    pub const PASSWORD                  :&str = "password";
     /// 打开一个会话
-    pub const SESSION                   :&'static str = "session";
+    pub const SESSION                   :&str = "session";
     /// 启动一个命令解释程序
-    pub const SHELL                     :&'static str = "shell";
+    pub const SHELL                     :&str = "shell";
     /// 执行一个命令
-    pub const EXEC                      :&'static str = "exec";
+    pub const EXEC                      :&str = "exec";
     /// 执行文件传输
-    pub const SCP                       :&'static str = "scp";
+    pub const SCP                       :&str = "scp";
     /// 请求一个伪终端
-    pub const PTY_REQ                   :&'static str = "pty-req";
+    pub const PTY_REQ                   :&str = "pty-req";
     /// 伪终端的样式
-    pub const XTERM_VAR                 :&'static str = "xterm-256color";
+    pub const XTERM_VAR                 :&str = "xterm-256color";
 }
 
 #[allow(dead_code)]
 pub mod permission {
     /// 文件夹默认权限
-    pub const DIR                       :&'static str = "775";
+    pub const DIR                       :&str = "775";
     /// 文件默认权限
-    pub const FILE                      :&'static str = "664";
+    pub const FILE                      :&str = "664";
 }
 
 
@@ -42,33 +42,33 @@ pub mod permission {
 pub mod scp {
     // scp 参数常量
     /// 意味着当前机器上的scp，将本地文件传输到另一个scp上
-    pub const SOURCE                    :&'static str = "-f";
+    pub const SOURCE                    :&str = "-f";
     /// 意味着当前机器上的scp，即将收到另一个scp传输过来的文件
-    pub const SINK                      :&'static str = "-t";
+    pub const SINK                      :&str = "-t";
     /// 递归复制整个目录
-    pub const RECURSIVE                 :&'static str = "-r";
+    pub const RECURSIVE                 :&str = "-r";
     /// 详细方式显示输出
-    pub const VERBOSE                   :&'static str = "-v";
+    pub const VERBOSE                   :&str = "-v";
     /// 保留原文件的修改时间，访问时间和访问权限
-    pub const PRESERVE_TIMES            :&'static str = "-p";
+    pub const PRESERVE_TIMES            :&str = "-p";
     /// 不显示传输进度条
-    pub const QUIET                     :&'static str = "-q";
+    pub const QUIET                     :&str = "-q";
     /// 限定用户所能使用的带宽
-    pub const LIMIT                     :&'static str = "-l";
+    pub const LIMIT                     :&str = "-l";
 
     // scp传输时的状态常量
     /// 代表当前接收的数据是文件的最后修改时间和最后访问时间
     /// "T1647767946 0 1647767946 0\n";
-    pub const T                         :u8   = 'T' as u8;
+    pub const T                         :u8   = b'T';
     /// 代表当前接收的数据是文件夹
     /// "D0775 0 dirName\n"
-    pub const D                         :u8   = 'D' as u8;
+    pub const D                         :u8   = b'D';
     /// 代表当前接收的数据是文件
     /// "C0664 200 fileName.js\n"
-    pub const C                         :u8   = 'C' as u8;
+    pub const C                         :u8   = b'C';
     /// 代表当前文件夹传输结束，需要返回上层文件夹
     /// "D\n"
-    pub const E                         :u8   = 'E' as u8;
+    pub const E                         :u8   = b'E';
 
     /// 代表结束当前操作
     // '\0'
@@ -154,22 +154,22 @@ pub mod ssh_msg_code {
 #[allow(dead_code)]
 pub mod algorithms {
     /// 密钥交换算法
-    pub const DH_CURVE25519_SHA256                              :&'static str = "curve25519-sha256";
-    pub const DH_ECDH_SHA2_NISTP256                             :&'static str = "ecdh-sha2-nistp256";
+    pub const DH_CURVE25519_SHA256                              :&str = "curve25519-sha256";
+    pub const DH_ECDH_SHA2_NISTP256                             :&str = "ecdh-sha2-nistp256";
 
     /// 非对称签名算法
-    pub const PUBLIC_KEY_ED25519                                :&'static str = "ssh-ed25519";
-    pub const PUBLIC_KEY_RSA                                    :&'static str = "ssh-rsa";
+    pub const PUBLIC_KEY_ED25519                                :&str = "ssh-ed25519";
+    pub const PUBLIC_KEY_RSA                                    :&str = "ssh-rsa";
 
     /// 对称加密算法
-    pub const ENCRYPTION_CHACHA20_POLY1305_OPENSSH              :&'static str = "chacha20-poly1305@openssh.com";
-    pub const ENCRYPTION_AES128_CTR                             :&'static str = "aes128-ctr";
+    pub const ENCRYPTION_CHACHA20_POLY1305_OPENSSH              :&str = "chacha20-poly1305@openssh.com";
+    pub const ENCRYPTION_AES128_CTR                             :&str = "aes128-ctr";
 
     /// MAC（消息验证码）算法
-    pub const MAC_HMAC_SHA1                                     :&'static str = "hmac-sha1";
+    pub const MAC_HMAC_SHA1                                     :&str = "hmac-sha1";
 
     /// 压缩算法
-    pub const COMPRESSION_ALGORITHMS                            :&'static str = "none";
+    pub const COMPRESSION_ALGORITHMS                            :&str = "none";
 }
 
 /// 密钥交换后进行HASH时候需要的常量值

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,175 +1,167 @@
-
 /// 客户端版本
-pub const CLIENT_VERSION            :&str = "SSH-2.0-SSH_RS-0.2.1";
-
+pub const CLIENT_VERSION: &str = "SSH-2.0-SSH_RS-0.2.1";
 
 /// ssh通讯时用到的常量字符串
 #[allow(dead_code)]
 pub mod ssh_str {
     /// 准备认证
-    pub const SSH_USERAUTH              :&str = "ssh-userauth";
+    pub const SSH_USERAUTH: &str = "ssh-userauth";
     /// 开始认证
-    pub const SSH_CONNECTION            :&str = "ssh-connection";
+    pub const SSH_CONNECTION: &str = "ssh-connection";
     /// 公钥验证方式
-    pub const PUBLIC_KEY                :&str = "publickey";
+    pub const PUBLIC_KEY: &str = "publickey";
     /// 密码认证方式
-    pub const PASSWORD                  :&str = "password";
+    pub const PASSWORD: &str = "password";
     /// 打开一个会话
-    pub const SESSION                   :&str = "session";
+    pub const SESSION: &str = "session";
     /// 启动一个命令解释程序
-    pub const SHELL                     :&str = "shell";
+    pub const SHELL: &str = "shell";
     /// 执行一个命令
-    pub const EXEC                      :&str = "exec";
+    pub const EXEC: &str = "exec";
     /// 执行文件传输
-    pub const SCP                       :&str = "scp";
+    pub const SCP: &str = "scp";
     /// 请求一个伪终端
-    pub const PTY_REQ                   :&str = "pty-req";
+    pub const PTY_REQ: &str = "pty-req";
     /// 伪终端的样式
-    pub const XTERM_VAR                 :&str = "xterm-256color";
+    pub const XTERM_VAR: &str = "xterm-256color";
 }
 
 #[allow(dead_code)]
 pub mod permission {
     /// 文件夹默认权限
-    pub const DIR                       :&str = "775";
+    pub const DIR: &str = "775";
     /// 文件默认权限
-    pub const FILE                      :&str = "664";
+    pub const FILE: &str = "664";
 }
-
 
 /// scp 操作时用到的常量
 #[allow(dead_code)]
 pub mod scp {
     // scp 参数常量
     /// 意味着当前机器上的scp，将本地文件传输到另一个scp上
-    pub const SOURCE                    :&str = "-f";
+    pub const SOURCE: &str = "-f";
     /// 意味着当前机器上的scp，即将收到另一个scp传输过来的文件
-    pub const SINK                      :&str = "-t";
+    pub const SINK: &str = "-t";
     /// 递归复制整个目录
-    pub const RECURSIVE                 :&str = "-r";
+    pub const RECURSIVE: &str = "-r";
     /// 详细方式显示输出
-    pub const VERBOSE                   :&str = "-v";
+    pub const VERBOSE: &str = "-v";
     /// 保留原文件的修改时间，访问时间和访问权限
-    pub const PRESERVE_TIMES            :&str = "-p";
+    pub const PRESERVE_TIMES: &str = "-p";
     /// 不显示传输进度条
-    pub const QUIET                     :&str = "-q";
+    pub const QUIET: &str = "-q";
     /// 限定用户所能使用的带宽
-    pub const LIMIT                     :&str = "-l";
+    pub const LIMIT: &str = "-l";
 
     // scp传输时的状态常量
     /// 代表当前接收的数据是文件的最后修改时间和最后访问时间
     /// "T1647767946 0 1647767946 0\n";
-    pub const T                         :u8   = b'T';
+    pub const T: u8 = b'T';
     /// 代表当前接收的数据是文件夹
     /// "D0775 0 dirName\n"
-    pub const D                         :u8   = b'D';
+    pub const D: u8 = b'D';
     /// 代表当前接收的数据是文件
     /// "C0664 200 fileName.js\n"
-    pub const C                         :u8   = b'C';
+    pub const C: u8 = b'C';
     /// 代表当前文件夹传输结束，需要返回上层文件夹
     /// "D\n"
-    pub const E                         :u8   = b'E';
+    pub const E: u8 = b'E';
 
     /// 代表结束当前操作
     // '\0'
-    pub const END                       :u8   = 0;
+    pub const END: u8 = 0;
     /// scp操作异常
-    pub const ERR                       :u8   = 1;
+    pub const ERR: u8 = 1;
     /// scp操作比较严重的异常
-    pub const FATAL_ERR                 :u8   = 2;
+    pub const FATAL_ERR: u8 = 2;
 }
-
 
 /// 一些默认大小
 #[allow(dead_code)]
 pub mod size {
-    pub const ONE_GB                    :u32    = 1073741824;
+    pub const ONE_GB: u32 = 1073741824;
     /// 最大数据包大小
-    pub const BUF_SIZE                  :usize  = 32768;
+    pub const BUF_SIZE: usize = 32768;
     /// 默认客户端的窗口大小
-    pub const LOCAL_WINDOW_SIZE         :u32    = 2097152;
+    pub const LOCAL_WINDOW_SIZE: u32 = 2097152;
 }
-
 
 /// ssh 消息码
 #[allow(dead_code)]
 pub mod ssh_msg_code {
-    pub const SSH_MSG_DISCONNECT                                :u8 = 1;
-    pub const SSH_MSG_IGNORE                                    :u8 = 2;
-    pub const SSH_MSG_UNIMPLEMENTED                             :u8 = 3;
-    pub const SSH_MSG_DEBUG                                     :u8 = 4;
-    pub const SSH_MSG_SERVICE_REQUEST                           :u8 = 5;
-    pub const SSH_MSG_SERVICE_ACCEPT                            :u8 = 6;
-    pub const SSH_MSG_KEXINIT                                   :u8 = 20;
-    pub const SSH_MSG_NEWKEYS                                   :u8 = 21;
-    pub const SSH_MSG_KEXDH_INIT                                :u8 = 30;
-    pub const SSH_MSG_KEXDH_REPLY                               :u8 = 31;
-    pub const SSH_MSG_USERAUTH_REQUEST                          :u8 = 50;
-    pub const SSH_MSG_USERAUTH_FAILURE                          :u8 = 51;
-    pub const SSH_MSG_USERAUTH_SUCCESS                          :u8 = 52;
-    pub const SSH_MSG_USERAUTH_PK_OK                            :u8 = 60;
-    pub const SSH_MSG_GLOBAL_REQUEST                            :u8 = 80;
-    pub const SSH_MSG_REQUEST_SUCCESS                           :u8 = 81;
-    pub const SSH_MSG_REQUEST_FAILURE                           :u8 = 82;
-    pub const SSH_MSG_CHANNEL_OPEN                              :u8 = 90;
-    pub const SSH_MSG_CHANNEL_OPEN_CONFIRMATION                 :u8 = 91;
-    pub const SSH_MSG_CHANNEL_OPEN_FAILURE                      :u8 = 92;
-    pub const SSH_MSG_CHANNEL_WINDOW_ADJUST                     :u8 = 93;
-    pub const SSH_MSG_CHANNEL_DATA                              :u8 = 94;
-    pub const SSH_MSG_CHANNEL_EXTENDED_DATA                     :u8 = 95;
-    pub const SSH_MSG_CHANNEL_EOF                               :u8 = 96;
-    pub const SSH_MSG_CHANNEL_CLOSE                             :u8 = 97;
-    pub const SSH_MSG_CHANNEL_REQUEST                           :u8 = 98;
-    pub const SSH_MSG_CHANNEL_SUCCESS                           :u8 = 99;
-    pub const SSH_MSG_CHANNEL_FAILURE                           :u8 = 100;
-
+    pub const SSH_MSG_DISCONNECT: u8 = 1;
+    pub const SSH_MSG_IGNORE: u8 = 2;
+    pub const SSH_MSG_UNIMPLEMENTED: u8 = 3;
+    pub const SSH_MSG_DEBUG: u8 = 4;
+    pub const SSH_MSG_SERVICE_REQUEST: u8 = 5;
+    pub const SSH_MSG_SERVICE_ACCEPT: u8 = 6;
+    pub const SSH_MSG_KEXINIT: u8 = 20;
+    pub const SSH_MSG_NEWKEYS: u8 = 21;
+    pub const SSH_MSG_KEXDH_INIT: u8 = 30;
+    pub const SSH_MSG_KEXDH_REPLY: u8 = 31;
+    pub const SSH_MSG_USERAUTH_REQUEST: u8 = 50;
+    pub const SSH_MSG_USERAUTH_FAILURE: u8 = 51;
+    pub const SSH_MSG_USERAUTH_SUCCESS: u8 = 52;
+    pub const SSH_MSG_USERAUTH_PK_OK: u8 = 60;
+    pub const SSH_MSG_GLOBAL_REQUEST: u8 = 80;
+    pub const SSH_MSG_REQUEST_SUCCESS: u8 = 81;
+    pub const SSH_MSG_REQUEST_FAILURE: u8 = 82;
+    pub const SSH_MSG_CHANNEL_OPEN: u8 = 90;
+    pub const SSH_MSG_CHANNEL_OPEN_CONFIRMATION: u8 = 91;
+    pub const SSH_MSG_CHANNEL_OPEN_FAILURE: u8 = 92;
+    pub const SSH_MSG_CHANNEL_WINDOW_ADJUST: u8 = 93;
+    pub const SSH_MSG_CHANNEL_DATA: u8 = 94;
+    pub const SSH_MSG_CHANNEL_EXTENDED_DATA: u8 = 95;
+    pub const SSH_MSG_CHANNEL_EOF: u8 = 96;
+    pub const SSH_MSG_CHANNEL_CLOSE: u8 = 97;
+    pub const SSH_MSG_CHANNEL_REQUEST: u8 = 98;
+    pub const SSH_MSG_CHANNEL_SUCCESS: u8 = 99;
+    pub const SSH_MSG_CHANNEL_FAILURE: u8 = 100;
 
     // 异常消息码
-    pub const SSH_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT        :u8 = 1;
-    pub const SSH_DISCONNECT_PROTOCOL_ERROR                     :u8 = 2;
-    pub const SSH_DISCONNECT_KEY_EXCHANGE_FAILED                :u8 = 3;
-    pub const SSH_DISCONNECT_RESERVED                           :u8 = 4;
-    pub const SSH_DISCONNECT_MAC_ERROR                          :u8 = 5;
-    pub const SSH_DISCONNECT_COMPRESSION_ERROR                  :u8 = 6;
-    pub const SSH_DISCONNECT_SERVICE_NOT_AVAILABLE              :u8 = 7;
-    pub const SSH_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED     :u8 = 8;
-    pub const SSH_DISCONNECT_HOST_KEY_NOT_VERIFIABLE            :u8 = 9;
-    pub const SSH_DISCONNECT_CONNECTION_LOST                    :u8 = 10;
-    pub const SSH_DISCONNECT_BY_APPLICATION                     :u8 = 11;
-    pub const SSH_DISCONNECT_TOO_MANY_CONNECTIONS               :u8 = 12;
-    pub const SSH_DISCONNECT_AUTH_CANCELLED_BY_USER             :u8 = 13;
-    pub const SSH_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE     :u8 = 14;
-    pub const SSH_DISCONNECT_ILLEGAL_USER_NAME                  :u8 = 15;
-
+    pub const SSH_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT: u8 = 1;
+    pub const SSH_DISCONNECT_PROTOCOL_ERROR: u8 = 2;
+    pub const SSH_DISCONNECT_KEY_EXCHANGE_FAILED: u8 = 3;
+    pub const SSH_DISCONNECT_RESERVED: u8 = 4;
+    pub const SSH_DISCONNECT_MAC_ERROR: u8 = 5;
+    pub const SSH_DISCONNECT_COMPRESSION_ERROR: u8 = 6;
+    pub const SSH_DISCONNECT_SERVICE_NOT_AVAILABLE: u8 = 7;
+    pub const SSH_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED: u8 = 8;
+    pub const SSH_DISCONNECT_HOST_KEY_NOT_VERIFIABLE: u8 = 9;
+    pub const SSH_DISCONNECT_CONNECTION_LOST: u8 = 10;
+    pub const SSH_DISCONNECT_BY_APPLICATION: u8 = 11;
+    pub const SSH_DISCONNECT_TOO_MANY_CONNECTIONS: u8 = 12;
+    pub const SSH_DISCONNECT_AUTH_CANCELLED_BY_USER: u8 = 13;
+    pub const SSH_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE: u8 = 14;
+    pub const SSH_DISCONNECT_ILLEGAL_USER_NAME: u8 = 15;
 
     // 通道连接失败码 SSH_MSG_CHANNEL_OPEN_FAILURE
-    pub const SSH_OPEN_ADMINISTRATIVELY_PROHIBITED              :u32 = 1;
-    pub const SSH_OPEN_CONNECT_FAILED                           :u32 = 2;
-    pub const SSH_OPEN_UNKNOWN_CHANNEL_TYPE                     :u32 = 3;
-    pub const SSH_OPEN_RESOURCE_SHORTAGE                        :u32 = 4;
+    pub const SSH_OPEN_ADMINISTRATIVELY_PROHIBITED: u32 = 1;
+    pub const SSH_OPEN_CONNECT_FAILED: u32 = 2;
+    pub const SSH_OPEN_UNKNOWN_CHANNEL_TYPE: u32 = 3;
+    pub const SSH_OPEN_RESOURCE_SHORTAGE: u32 = 4;
 }
-
 
 /// 加密算法常量
 #[allow(dead_code)]
 pub mod algorithms {
     /// 密钥交换算法
-    pub const DH_CURVE25519_SHA256                              :&str = "curve25519-sha256";
-    pub const DH_ECDH_SHA2_NISTP256                             :&str = "ecdh-sha2-nistp256";
+    pub const DH_CURVE25519_SHA256: &str = "curve25519-sha256";
+    pub const DH_ECDH_SHA2_NISTP256: &str = "ecdh-sha2-nistp256";
 
     /// 非对称签名算法
-    pub const PUBLIC_KEY_ED25519                                :&str = "ssh-ed25519";
-    pub const PUBLIC_KEY_RSA                                    :&str = "ssh-rsa";
+    pub const PUBLIC_KEY_ED25519: &str = "ssh-ed25519";
+    pub const PUBLIC_KEY_RSA: &str = "ssh-rsa";
 
     /// 对称加密算法
-    pub const ENCRYPTION_CHACHA20_POLY1305_OPENSSH              :&str = "chacha20-poly1305@openssh.com";
-    pub const ENCRYPTION_AES128_CTR                             :&str = "aes128-ctr";
+    pub const ENCRYPTION_CHACHA20_POLY1305_OPENSSH: &str = "chacha20-poly1305@openssh.com";
+    pub const ENCRYPTION_AES128_CTR: &str = "aes128-ctr";
 
     /// MAC（消息验证码）算法
-    pub const MAC_HMAC_SHA1                                     :&str = "hmac-sha1";
+    pub const MAC_HMAC_SHA1: &str = "hmac-sha1";
 
     /// 压缩算法
-    pub const COMPRESSION_ALGORITHMS                            :&str = "none";
+    pub const COMPRESSION_ALGORITHMS: &str = "none";
 }
 
 /// 密钥交换后进行HASH时候需要的常量值

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,5 @@
 use std::ops::{Deref, DerefMut};
 
-
 /// **byte**
 /// byte 标识任意一个 8 位值（8 位字节）。固定长度的数据有时被表示为一个字节数组，写
 /// 作 byte[[n]]，其中 n 是数组中字节的数量。
@@ -43,10 +42,15 @@ use std::ops::{Deref, DerefMut};
 #[derive(Debug, Clone)]
 pub struct Data(Vec<u8>);
 
-impl Data {
+impl Default for Data {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
+impl Data {
     pub fn new() -> Data {
-        Data { 0: vec![] }
+        Data(Vec::new())
     }
 
     // 把字节数组置空
@@ -117,9 +121,7 @@ impl Data {
         // 4位字节反转后直接转成u32类型
         self.0 = (&self.0[4..]).to_vec();
         a.reverse();
-        unsafe {
-            *(a.as_ptr() as *const u32)
-        }
+        unsafe { *(a.as_ptr() as *const u32) }
     }
 
     // 获取字节数组
@@ -130,7 +132,6 @@ impl Data {
         bytes
     }
 }
-
 
 impl From<Vec<u8>> for Data {
     fn from(v: Vec<u8>) -> Self {
@@ -144,9 +145,9 @@ impl From<&[u8]> for Data {
     }
 }
 
-impl Into<Vec<u8>> for Data {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<Data> for Vec<u8> {
+    fn from(data: Data) -> Self {
+        data.0
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,8 +24,7 @@ impl Debug for SshError {
                 write!(
                     f,
                     r"Error: {{ Kind({:?}), Message({}) }}",
-                    self.inner,
-                    self.inner
+                    self.inner, self.inner
                 )
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,11 @@
+use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::{fmt, io};
-use std::error::Error;
-
 
 pub type SshResult<I> = Result<I, SshError>;
 
 pub struct SshError {
-    inner: SshErrorKind
+    inner: SshErrorKind,
 }
 
 impl SshError {
@@ -15,14 +14,20 @@ impl SshError {
     }
 }
 
-
 impl Debug for SshError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.inner {
             SshErrorKind::IoError(ie) => {
-                write!(f, r"IoError: {{ Kind({:?}), Message({}) }}", ie.kind(), ie.to_string())
+                write!(f, r"IoError: {{ Kind({:?}), Message({}) }}", ie.kind(), ie)
             }
-            _ => { write!(f, r"Error: {{ Kind({:?}), Message({}) }}", self.inner, self.inner.to_string()) }
+            _ => {
+                write!(
+                    f,
+                    r"Error: {{ Kind({:?}), Message({}) }}",
+                    self.inner,
+                    self.inner
+                )
+            }
         }
     }
 }
@@ -33,21 +38,19 @@ impl Display for SshError {
             SshErrorKind::IoError(ie) => {
                 write!(f, r"IoError: {{ Kind({:?}) }}", ie.kind())
             }
-            _ => { write!(f, r"Error: {{ Kind({:?}) }}", self.inner) }
+            _ => {
+                write!(f, r"Error: {{ Kind({:?}) }}", self.inner)
+            }
         }
-
     }
 }
-
 
 #[derive(Debug)]
 pub enum SshErrorKind {
     IoError(io::Error),
     SshError(String),
-    Timeout
+    Timeout,
 }
-
-
 
 impl PartialEq<Self> for SshErrorKind {
     fn eq(&self, other: &Self) -> bool {
@@ -55,40 +58,33 @@ impl PartialEq<Self> for SshErrorKind {
             (&SshErrorKind::SshError(v1), &SshErrorKind::SshError(v2)) => v1.eq(v2),
             (&SshErrorKind::IoError(io1), &SshErrorKind::IoError(io2)) => io1.kind() == io2.kind(),
             (&SshErrorKind::Timeout, &SshErrorKind::Timeout) => true,
-            _ => false
+            _ => false,
         }
     }
 }
 
-
-
-
-impl SshErrorKind {
-    fn to_string(&self) -> String {
+impl fmt::Display for SshErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
-            SshErrorKind::SshError(e) => e.to_string(),
-            SshErrorKind::IoError(v) => v.to_string(),
-            SshErrorKind::Timeout => "time out.".to_string()
+            SshErrorKind::SshError(e) => write!(f, "{}", e),
+            SshErrorKind::IoError(v) => write!(f, "{}", v),
+            SshErrorKind::Timeout => write!(f, "time out."),
         }
     }
 }
 
-
-impl Error for SshError {
-}
+impl Error for SshError {}
 
 impl From<SshErrorKind> for SshError {
     fn from(kind: SshErrorKind) -> SshError {
-        SshError {
-            inner: kind
-        }
+        SshError { inner: kind }
     }
 }
 
 impl From<&str> for SshError {
     fn from(kind: &str) -> SshError {
         SshError {
-            inner: SshErrorKind::SshError(kind.to_string())
+            inner: SshErrorKind::SshError(kind.to_string()),
         }
     }
 }
@@ -96,7 +92,7 @@ impl From<&str> for SshError {
 impl From<String> for SshError {
     fn from(kind: String) -> SshError {
         SshError {
-            inner: SshErrorKind::SshError(kind)
+            inner: SshErrorKind::SshError(kind),
         }
     }
 }
@@ -104,7 +100,7 @@ impl From<String> for SshError {
 impl From<io::Error> for SshError {
     fn from(kind: io::Error) -> Self {
         SshError {
-            inner: SshErrorKind::IoError(io::Error::from(kind.kind()))
+            inner: SshErrorKind::IoError(io::Error::from(kind.kind())),
         }
     }
 }

--- a/src/h.rs
+++ b/src/h.rs
@@ -11,7 +11,6 @@ use crate::data::Data;
 ///
 #[derive(Clone)]
 pub struct H {
-
     /// 一下数据如果有从数据包解析的数据
     /// 统一不包含数据包里面的 PacketLength PaddingLength  PaddingString
 
@@ -23,7 +22,6 @@ pub struct H {
     /// 数据    [str]
     pub v_c: Vec<u8>,
     pub v_s: Vec<u8>,
-
 
     /// 双方(客户端/服务端)交换的算法，
     /// 数据长度 + 数据
@@ -45,7 +43,7 @@ pub struct H {
 
     /// 共享密钥
     /// 二进制补码 + 数据
-    pub k  : Vec<u8>,
+    pub k: Vec<u8>,
 }
 
 impl H {
@@ -58,10 +56,9 @@ impl H {
             k_s: vec![],
             q_c: vec![],
             q_s: vec![],
-            k: vec![]
+            k: vec![],
         }
     }
-
 
     pub fn set_v_c(&mut self, vc: &str) {
         let mut data = Data::new();
@@ -104,18 +101,16 @@ impl H {
         self.k = data.to_vec();
     }
 
-
     pub fn as_bytes(&self) -> Vec<u8> {
         let mut v = vec![];
-        v.extend(& self.v_c);
-        v.extend(& self.v_s);
-        v.extend(& self.i_c);
-        v.extend(& self.i_s);
-        v.extend(& self.k_s);
-        v.extend(& self.q_c);
-        v.extend(& self.q_s);
-        v.extend(& self.k);
+        v.extend(&self.v_c);
+        v.extend(&self.v_s);
+        v.extend(&self.i_c);
+        v.extend(&self.i_s);
+        v.extend(&self.k_s);
+        v.extend(&self.q_c);
+        v.extend(&self.q_s);
+        v.extend(&self.k);
         v
     }
-
 }

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -1,40 +1,30 @@
-use crate::constant::ssh_msg_code;
-use crate::error::{SshError, SshResult};
-use crate::data::Data;
-use crate::slog::log;
-use crate::config::{
-    Config,
-    CompressionAlgorithm,
-    EncryptionAlgorithm,
-    KeyExchangeAlgorithm,
-    MacAlgorithm,
-    PublicKeyAlgorithm
-};
-use crate::{
-    util,
-    h::H,
-    client::Client,
-};
 use crate::algorithm::hash;
 use crate::algorithm::key_exchange::KeyExchange;
 use crate::algorithm::public_key::PublicKey;
-
-
+use crate::config::{
+    CompressionAlgorithm, Config, EncryptionAlgorithm, KeyExchangeAlgorithm, MacAlgorithm,
+    PublicKeyAlgorithm,
+};
+use crate::constant::ssh_msg_code;
+use crate::data::Data;
+use crate::error::{SshError, SshResult};
+use crate::slog::log;
+use crate::{client::Client, h::H, util};
 
 /// 发送客户端的算法列表
-pub(crate) fn send_algorithm(h: &mut H,
-                             client: &mut Client,
-                             config: &mut Config
-) -> SshResult<()> {
-    log::info!("client algorithms: [{}]", config.algorithm.client_algorithm.to_string());
+pub(crate) fn send_algorithm(h: &mut H, client: &mut Client, config: &mut Config) -> SshResult<()> {
+    log::info!(
+        "client algorithms: [{}]",
+        config.algorithm.client_algorithm.to_string()
+    );
     let mut data = Data::new();
     data.put_u8(ssh_msg_code::SSH_MSG_KEXINIT);
     data.extend(util::cookie());
     data.extend(config.algorithm.client_algorithm.as_i());
     data.put_str("")
-    .put_str("")
-    .put_u8(false as u8)
-    .put_u32(0_u32);
+        .put_str("")
+        .put_u8(false as u8)
+        .put_u32(0_u32);
     // 客户端算法
     h.set_i_c(data.clone().as_slice());
     client.write(data)?;
@@ -42,22 +32,22 @@ pub(crate) fn send_algorithm(h: &mut H,
 }
 
 /// 获取服务端的算法列表
-pub(crate) fn receive_algorithm(h: &mut H,
-                                client: &mut Client,
-                                config: &mut Config
+pub(crate) fn receive_algorithm(
+    h: &mut H,
+    client: &mut Client,
+    config: &mut Config,
 ) -> SshResult<()> {
     loop {
         let results = client.read()?;
         for result in results {
-            if result.is_empty() { continue }
+            if result.is_empty() {
+                continue;
+            }
             let message_code = result[0];
-            match message_code {
-                ssh_msg_code::SSH_MSG_KEXINIT => {
-                    h.set_i_s(result.clone().as_slice());
-                    processing_server_algorithm(config, result)?;
-                    return Ok(());
-                }
-                _ => {}
+            if let ssh_msg_code::SSH_MSG_KEXINIT = message_code {
+                h.set_i_s(result.as_slice());
+                processing_server_algorithm(config, result)?;
+                return Ok(());
             }
         }
     }
@@ -69,18 +59,23 @@ fn processing_server_algorithm(config: &mut Config, mut data: Data) -> SshResult
     // 跳过16位cookie
     data.skip(16);
     let server_algorithm = &mut config.algorithm.server_algorithm;
-    server_algorithm.key_exchange_algorithm     =   KeyExchangeAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
-    server_algorithm.public_key_algorithm       =   PublicKeyAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
-    server_algorithm.c_encryption_algorithm     =   EncryptionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
-    server_algorithm.s_encryption_algorithm     =   EncryptionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
-    server_algorithm.c_mac_algorithm            =   MacAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
-    server_algorithm.s_mac_algorithm            =   MacAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
-    server_algorithm.c_compression_algorithm    =   CompressionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
-    server_algorithm.s_compression_algorithm    =   CompressionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.key_exchange_algorithm =
+        KeyExchangeAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.public_key_algorithm =
+        PublicKeyAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.c_encryption_algorithm =
+        EncryptionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.s_encryption_algorithm =
+        EncryptionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.c_mac_algorithm = MacAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.s_mac_algorithm = MacAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.c_compression_algorithm =
+        CompressionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
+    server_algorithm.s_compression_algorithm =
+        CompressionAlgorithm(util::vec_u8_to_string(data.get_u8s(), ",")?);
     log::info!("server algorithms: [{}]", server_algorithm.to_string());
-    return Ok(())
+    Ok(())
 }
-
 
 /// 发送客户端公钥
 pub(crate) fn send_qc(client: &mut Client, public_key: &[u8]) -> SshResult<()> {
@@ -91,34 +86,36 @@ pub(crate) fn send_qc(client: &mut Client, public_key: &[u8]) -> SshResult<()> {
 }
 
 /// 接收服务端公钥和签名，并验证签名的正确性
-pub(crate) fn verify_signature_and_new_keys(client: &mut Client,
-                                            public_key: &mut Box<dyn PublicKey>,
-                                            key_exchange: &mut Box<dyn KeyExchange>,
-                                            h: &mut H
-) -> SshResult<Vec<u8>>
-{
+pub(crate) fn verify_signature_and_new_keys(
+    client: &mut Client,
+    public_key: &mut Box<dyn PublicKey>,
+    key_exchange: &mut Box<dyn KeyExchange>,
+    h: &mut H,
+) -> SshResult<Vec<u8>> {
     let mut session_id = vec![];
     loop {
         let results = client.read()?;
         for mut result in results {
-            if result.is_empty() { continue }
+            if result.is_empty() {
+                continue;
+            }
             let message_code = result.get_u8();
             match message_code {
                 ssh_msg_code::SSH_MSG_KEXDH_REPLY => {
                     // 生成session_id并且获取signature
                     let sig = generate_signature(result, h, key_exchange)?;
                     // 验签
-                    session_id = hash::digest( &h.as_bytes(), key_exchange.get_hash_type());
+                    session_id = hash::digest(&h.as_bytes(), key_exchange.get_hash_type());
                     let flag = public_key.verify_signature(&h.k_s, &session_id, &sig)?;
                     if !flag {
                         log::error!("signature verification failure.");
-                        return Err(SshError::from("signature verification failure."))
+                        return Err(SshError::from("signature verification failure."));
                     }
                     log::info!("signature verification success.");
                 }
                 ssh_msg_code::SSH_MSG_NEWKEYS => {
                     new_keys(client)?;
-                    return Ok(session_id)
+                    return Ok(session_id);
                 }
                 _ => {}
             }
@@ -127,11 +124,11 @@ pub(crate) fn verify_signature_and_new_keys(client: &mut Client,
 }
 
 /// 生成签名
-pub(crate) fn generate_signature(mut data: Data,
-                                 h: &mut H,
-                                 key_exchange: &mut Box<dyn KeyExchange>
-) -> SshResult<Vec<u8>>
-{
+pub(crate) fn generate_signature(
+    mut data: Data,
+    h: &mut H,
+    key_exchange: &mut Box<dyn KeyExchange>,
+) -> SshResult<Vec<u8>> {
     let ks = data.get_u8s();
     h.set_k_s(&ks);
     // TODO 未进行密钥指纹验证！！
@@ -147,7 +144,6 @@ pub(crate) fn generate_signature(mut data: Data,
     Ok(signature)
 }
 
-
 /// SSH_MSG_NEWKEYS 代表密钥交换完成
 pub(crate) fn new_keys(client: &mut Client) -> Result<(), SshError> {
     let mut data = Data::new();
@@ -157,10 +153,10 @@ pub(crate) fn new_keys(client: &mut Client) -> Result<(), SshError> {
     Ok(())
 }
 
-
-pub(crate) fn key_agreement(h: &mut H,
-                            client: &mut Client,
-                            config: &mut Config
+pub(crate) fn key_agreement(
+    h: &mut H,
+    client: &mut Client,
+    config: &mut Config,
 ) -> SshResult<hash::HashType> {
     log::info!("start for key negotiation.");
     log::info!("send client algorithm list.");
@@ -176,7 +172,7 @@ pub(crate) fn key_agreement(h: &mut H,
 
     let hash_type = key_exchange.get_hash_type();
 
-    let hash = hash::hash::HASH::new(h.clone(), &session_id, hash_type);
+    let hash = hash::hash::Hash::new(h.clone(), &session_id, hash_type);
     // mac 算法
     let mac = config.algorithm.matching_mac_algorithm()?;
     // 加密算法
@@ -186,11 +182,11 @@ pub(crate) fn key_agreement(h: &mut H,
     client.is_encryption = true;
     if client.session_id.is_empty() {
         if session_id.is_empty() {
-            return Err(SshError::from("session id is none."))
+            return Err(SshError::from("session id is none."));
         }
         client.session_id = session_id;
     }
-    
+
     log::info!("key negotiation successful.");
     Ok(hash_type)
 }

--- a/src/key_pair.rs
+++ b/src/key_pair.rs
@@ -1,32 +1,27 @@
+use crate::algorithm::hash;
+use crate::algorithm::hash::HashType;
+use crate::data::Data;
+use crate::h::H;
+use crate::{SshError, SshResult};
+use rsa::pkcs1::FromRsaPrivateKey;
+use rsa::PublicKeyParts;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use rsa::pkcs1::FromRsaPrivateKey;
-use rsa::PublicKeyParts;
-use crate::data::Data;
-use crate::{SshError, SshResult};
-use crate::algorithm::hash;
-use crate::algorithm::hash::HashType;
-use crate::h::H;
 
+#[derive(Default)]
 pub struct KeyPair {
     pub(crate) private_key: String,
     pub(crate) key_type: String,
     pub(crate) blob: Vec<u8>,
 }
 
-
-
 impl KeyPair {
-
     pub fn new() -> Self {
         KeyPair {
-            private_key: "".to_string(),
-            key_type: "".to_string(),
-            blob: vec![]
+            ..Default::default()
         }
     }
-
 
     pub fn from_path<P: AsRef<Path>>(key_path: P, key_type: KeyPairType) -> SshResult<Self> {
         let mut file = File::open(key_path).unwrap();
@@ -35,14 +30,11 @@ impl KeyPair {
         KeyPair::from_str(&prks, key_type)
     }
 
-
     pub fn from_str(key_str: &str, key_type: KeyPairType) -> SshResult<Self> {
         let key_type_str = KeyPairType::get_string(key_type);
         let rprk = match rsa::RsaPrivateKey::from_pkcs1_pem(key_str) {
             Ok(e) => e,
-            Err(e) => {
-                return Err(SshError::from(e.to_string()))
-            }
+            Err(e) => return Err(SshError::from(e.to_string())),
         };
         let rpuk = rprk.to_public_key();
         let es = rpuk.e().to_bytes_be();
@@ -55,7 +47,7 @@ impl KeyPair {
         let pair = KeyPair {
             private_key: key_str.to_string(),
             key_type: key_type_str.to_string(),
-            blob
+            blob,
         };
         Ok(pair)
     }
@@ -70,11 +62,10 @@ impl KeyPair {
         sd.put_u8s(session_id.as_slice());
         sd.extend_from_slice(buf);
         let scheme = rsa::PaddingScheme::PKCS1v15Sign {
-            hash: Some(rsa::Hash::SHA1)
+            hash: Some(rsa::Hash::SHA1),
         };
         let digest = ring::digest::digest(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY, sd.as_slice());
         let msg = digest.as_ref();
-
 
         let rprk = rsa::RsaPrivateKey::from_pkcs1_pem(self.private_key.as_str()).unwrap();
 
@@ -86,18 +77,14 @@ impl KeyPair {
     }
 }
 
-
-
 pub enum KeyPairType {
-    SshRsa
+    SshRsa,
 }
 
 impl KeyPairType {
     pub(crate) fn get_string<'a>(key_type: KeyPairType) -> &'a str {
         match key_type {
-            KeyPairType::SshRsa => "ssh-rsa"
+            KeyPairType::SshRsa => "ssh-rsa",
         }
     }
 }
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,87 +1,77 @@
 //! Dependencies
-//! ```
+//! ```toml
 //! ssh-rs = "0.2.1"
 //! ```
 //!
 //! ## Connection method：
 //!
 //! ### 1. Password:
-//! ```rust
+//! ```no_run
 //! use ssh_rs::{Session, ssh};
 //!
-//! fn main() {
-//!     let mut session: Session = ssh::create_session();
-//!     session.set_user_and_password("user", "password");
-//!     session.connect("ip:port").unwrap();
-//! }
+//! let mut session: Session = ssh::create_session();
+//! session.set_user_and_password("user", "password");
+//! session.connect("ip:port").unwrap();
 //! ```
 //!
 //! ### 2. Public key:
 //! #### Currently, only `RSA-PKCS#1-PEM` type encrypted files with the encryption format `-----BEGIN RSA PRIVATE KEY-----` are supported.
 //!
 //! #### 1. Use key file path：
-//! ```rust
+//! ```no_run
 //! use ssh_rs::{Session, ssh};
 //! use ssh_rs::key_pair::KeyPairType;
 //!
-//! fn main() {
-//!     let mut session: Session = ssh::create_session();
-//!     // pem format key path -> /xxx/xxx/id_rsa
-//!     // KeyPairType::SshRsa -> Rsa type algorithm, currently only supports rsa.
-//!     session.set_user_and_key_pair_path("user", "pem format key path", KeyPairType::SshRsa).unwrap();
-//!     session.connect("ip:port").unwrap();
-//! }
+//! let mut session: Session = ssh::create_session();
+//! // pem format key path -> /xxx/xxx/id_rsa
+//! // KeyPairType::SshRsa -> Rsa type algorithm, currently only supports rsa.
+//! session.set_user_and_key_pair_path("user", "pem format key path", KeyPairType::SshRsa).unwrap();
+//! session.connect("ip:port").unwrap();
 //! ```
 //!
 //! #### 2. Use key string：
-//! ```rust
+//! ```no_run
 //! use ssh_rs::{Session, ssh};
 //! use ssh_rs::key_pair::KeyPairType;
 //!
-//! fn main() {
-//!     let mut session: Session = ssh::create_session();
-//!     // pem format key string:
-//!     //      -----BEGIN RSA PRIVATE KEY-----
-//!     //          xxxxxxxxxxxxxxxxxxxxx
-//!     //      -----END RSA PRIVATE KEY-----
-//!     // KeyPairType::SshRsa -> Rsa type algorithm, currently only supports rsa.
-//!     session.set_user_and_key_pair("user", "pem format key string", KeyPairType::SshRsa).unwrap();
-//!     session.connect("ip:port").unwrap();
-//! }
+//! let mut session: Session = ssh::create_session();
+//! // pem format key string:
+//! //      -----BEGIN RSA PRIVATE KEY-----
+//! //          xxxxxxxxxxxxxxxxxxxxx
+//! //      -----END RSA PRIVATE KEY-----
+//! // KeyPairType::SshRsa -> Rsa type algorithm, currently only supports rsa.
+//! session.set_user_and_key_pair("user", "pem format key string", KeyPairType::SshRsa).unwrap();
+//! session.connect("ip:port").unwrap();
 //! ```
 //!
 //! ## Enable global logging：
 //!
-//! ```rust
+//! ```no_run
 //! use ssh_rs::{Session, ssh};
 //!
-//! fn main() {
-//!     // is_enable_log Whether to enable global logging
-//!     // The default is false(Do not enable)
-//!     // Can be set as true (enable)
-//!     ssh::is_enable_log(true);
+//! // is_enable_log Whether to enable global logging
+//! // The default is false(Do not enable)
+//! // Can be set as true (enable)
+//! ssh::is_enable_log(true);
 //!
-//!     let mut session: Session = ssh::create_session();
-//!     session.set_user_and_password("user", "password");
-//!     session.connect("ip:port").unwrap();
-//! }
+//! let mut session: Session = ssh::create_session();
+//! session.set_user_and_password("user", "password");
+//! session.connect("ip:port").unwrap();
 //! ```
 //!
 //!
 //! ## Set timeout：
 //!
-//! ```rust
+//! ```no_run
 //! use ssh_rs::{Session, ssh};
 //!
-//! fn main() {
-//!     let mut session: Session = ssh::create_session();
-//!     // set_timeout
-//!     // The unit is seconds
-//!     // The default timeout is 30 seconds
-//!     session.set_timeout(15);
-//!     session.set_user_and_password("user", "password");
-//!     session.connect("ip:port").unwrap();
-//! }
+//! let mut session: Session = ssh::create_session();
+//! // set_timeout
+//! // The unit is seconds
+//! // The default timeout is 30 seconds
+//! session.set_timeout(15);
+//! session.set_user_and_password("user", "password");
+//! session.connect("ip:port").unwrap();
 //! ```
 //!
 //!
@@ -91,46 +81,42 @@
 //!
 //! ### 1. exec
 //!
-//! ```rust
+//! ```no_run
 //! use ssh_rs::{ChannelExec, Session, ssh};
 //!
-//! fn main() {
-//!     let mut session: Session = session();
-//!     // Usage 1
-//!     let exec: ChannelExec = session.open_exec().unwrap();
-//!     let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
-//!     println!("{}", String::from_utf8(vec).unwrap());
-//!     // Usage 2
-//!     let channel = session.open_channel().unwrap();
-//!     let exec = channel.open_exec().unwrap();
-//!     let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
-//!     println!("{}", String::from_utf8(vec).unwrap());
-//!     // Close session.
-//!     session.close().unwrap();
-//! }
+//! let mut session: Session = ssh::create_session();
+//! // Usage 1
+//! let exec: ChannelExec = session.open_exec().unwrap();
+//! let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
+//! println!("{}", String::from_utf8(vec).unwrap());
+//! // Usage 2
+//! let channel = session.open_channel().unwrap();
+//! let exec = channel.open_exec().unwrap();
+//! let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
+//! println!("{}", String::from_utf8(vec).unwrap());
+//! // Close session.
+//! session.close().unwrap();
 //! ```
 //!
 //! ### 2. shell
 //!
-//! ```rust
+//! ```no_run
 //! use std::thread::sleep;
 //! use std::time::Duration;
 //! use ssh_rs::{Channel, ChannelShell, Session, ssh};
 //!
-//! fn main() {
-//!     let mut session: Session = session();
-//!     // Usage 1
-//!     let mut shell: ChannelShell = session.open_shell().unwrap();
-//!     run_shell(&mut shell);
-//!     // Usage 2
-//!     let channel: Channel = session.open_channel().unwrap();
-//!     let mut shell = channel.open_shell().unwrap();
-//!     run_shell(&mut shell);
-//!     // Close channel.
-//!     shell.close().unwrap();
-//!     // Close session.
-//!     session.close().unwrap();
-//! }
+//! let mut session: Session = ssh::create_session();
+//! // Usage 1
+//! let mut shell: ChannelShell = session.open_shell().unwrap();
+//! run_shell(&mut shell);
+//! // Usage 2
+//! let channel: Channel = session.open_channel().unwrap();
+//! let mut shell = channel.open_shell().unwrap();
+//! run_shell(&mut shell);
+//! // Close channel.
+//! shell.close().unwrap();
+//! // Close session.
+//! session.close().unwrap();
 //!
 //! fn run_shell(shell: &mut ChannelShell) {
 //!     sleep(Duration::from_millis(500));
@@ -148,78 +134,71 @@
 //!
 //! ### 3. scp
 //!
-//! ```rust
+//! ```no_run
 //! use ssh_rs::{Channel, ChannelScp, Session, ssh};
 //!
-//! fn main() {
-//!     let mut session: Session = session();
-//!     // Usage 1
-//!     let scp: ChannelScp = session.open_scp().unwrap();
-//!     scp.upload("local path", "remote path").unwrap();
+//! let mut session: Session = ssh::create_session();
+//! // Usage 1
+//! let scp: ChannelScp = session.open_scp().unwrap();
+//! scp.upload("local path", "remote path").unwrap();
 //!
-//!     let scp: ChannelScp = session.open_scp().unwrap();
-//!     scp.download("local path", "remote path").unwrap();
+//! let scp: ChannelScp = session.open_scp().unwrap();
+//! scp.download("local path", "remote path").unwrap();
 //!
-//!     // Usage 2
-//!     let channel: Channel = session.open_channel().unwrap();
-//!     let scp: ChannelScp = channel.open_scp().unwrap();
-//!     scp.upload("local path", "remote path").unwrap();
+//! // Usage 2
+//! let channel: Channel = session.open_channel().unwrap();
+//! let scp: ChannelScp = channel.open_scp().unwrap();
+//! scp.upload("local path", "remote path").unwrap();
 //!
-//!     let channel: Channel = session.open_channel().unwrap();
-//!     let scp: ChannelScp = channel.open_scp().unwrap();
-//!     scp.download("local path", "remote path").unwrap();
+//! let channel: Channel = session.open_channel().unwrap();
+//! let scp: ChannelScp = channel.open_scp().unwrap();
+//! scp.download("local path", "remote path").unwrap();
 //!
-//!     session.close().unwrap();
-//! }
+//! session.close().unwrap();
 //!
 //! ```
 
-
-
 extern crate core;
 
-mod client;
-mod client_r;
-mod client_w;
-mod session;
-mod session_auth;
+mod algorithm;
 mod channel;
-mod kex;
-mod channel_shell;
 mod channel_exec;
 mod channel_scp;
 mod channel_scp_d;
 mod channel_scp_u;
+mod channel_shell;
+mod client;
+mod client_r;
+mod client_w;
 mod config;
-mod util;
-mod window_size;
-mod slog;
 mod constant;
 mod data;
+mod kex;
 mod packet;
-mod algorithm;
-mod user_info;
+mod session;
+mod session_auth;
+mod slog;
 mod timeout;
+mod user_info;
+mod util;
+mod window_size;
 
-
-pub mod key_pair;
 pub mod error;
 pub(crate) mod h;
+pub mod key_pair;
 
-pub use session::Session;
 pub use channel::Channel;
-pub use channel_shell::ChannelShell;
 pub use channel_exec::ChannelExec;
 pub use channel_scp::ChannelScp;
+pub use channel_shell::ChannelShell;
+pub use session::Session;
 pub use user_info::UserInfo;
-
 
 use crate::error::{SshError, SshResult};
 
-
 pub mod ssh {
-    use crate::Session;
     use crate::slog::Slog;
+    use crate::Session;
 
     pub fn create_session() -> Session {
         Session {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,7 +1,6 @@
 use crate::algorithm::encryption::Encryption;
 use crate::data::Data;
 
-
 /// ## 数据包整体结构
 ///
 /// ### uint32 `packet_length`
@@ -40,17 +39,15 @@ use crate::data::Data;
 #[derive(Debug)]
 pub struct Packet {
     data: Data,
-    value: Vec<u8>
+    value: Vec<u8>,
 }
 
-
 impl Packet {
-
     pub fn unpacking(&mut self) -> Data {
         if self.value.is_empty() {
-            return Data::new()
+            return Data::new();
         }
-        let padding_length = *(&self.value[4]);
+        let padding_length = self.value[4];
         let vec = (&self.value[5..(self.value.len() - padding_length as usize)]).to_vec();
         let data = Data::from(vec);
         self.data = data.clone();
@@ -64,17 +61,20 @@ impl Packet {
     }
 
     // 封包
-    pub fn build(&mut self, encryption: Option<&Box<dyn Encryption>>, is_encrypt: bool) {
-        let data_len =  self.data.len() as u32;
+    pub fn build(&mut self, encryption: Option<&dyn Encryption>, is_encrypt: bool) {
+        let data_len = self.data.len() as u32;
         let bsize = match is_encrypt {
-                true => encryption.unwrap().bsize() as i32,
-                // 未加密的填充: 整个包的总长度是8的倍数，并且填充长度不能小于4
-                false => 8,
+            true => encryption.unwrap().bsize() as i32,
+            // 未加密的填充: 整个包的总长度是8的倍数，并且填充长度不能小于4
+            false => 8,
         };
         let padding_len = {
-            let mut pad = (-((data_len +
-                if is_encrypt && encryption.unwrap().is_cp() { 1 }
-                else { 5 }) as i32))
+            let mut pad = (-((data_len
+                + if is_encrypt && encryption.unwrap().is_cp() {
+                    1
+                } else {
+                    5
+                }) as i32))
                 & (bsize - 1) as i32;
             if pad < bsize {
                 pad += bsize;
@@ -92,7 +92,7 @@ impl Packet {
         buf.extend(vec![0; padding_len as usize]);
         // 获取总长度
         let packet_len = buf.len() as u32;
-        let mut packet_len_u8s= packet_len.to_be_bytes().to_vec();
+        let mut packet_len_u8s = packet_len.to_be_bytes().to_vec();
         // [packet_length, padding_length, payload, randomPadding]
         packet_len_u8s.extend(buf);
         self.value = packet_len_u8s;
@@ -106,14 +106,13 @@ impl Packet {
     pub fn to_vec(&self) -> Vec<u8> {
         self.value.to_vec()
     }
-
 }
 
 impl From<Vec<u8>> for Packet {
     fn from(v: Vec<u8>) -> Self {
         Packet {
             data: Data::from(v.as_slice()),
-            value: v
+            value: v,
         }
     }
 }
@@ -122,7 +121,7 @@ impl From<&[u8]> for Packet {
     fn from(v: &[u8]) -> Self {
         Packet {
             data: Data::from(v),
-            value: v.to_vec()
+            value: v.to_vec(),
         }
     }
 }
@@ -132,7 +131,7 @@ impl From<Data> for Packet {
         let vec = d.as_slice().to_vec();
         Packet {
             data: d,
-            value: vec
+            value: vec,
         }
     }
 }

--- a/src/session_auth.rs
+++ b/src/session_auth.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-use crate::{Session, SshError, SshResult};
 use crate::algorithm::hash::HashType;
 use crate::config::Config;
 use crate::constant::{ssh_msg_code, ssh_str};
@@ -7,12 +5,13 @@ use crate::data::Data;
 use crate::h::H;
 use crate::key_pair::{KeyPair, KeyPairType};
 use crate::user_info::UserInfo;
+use crate::{Session, SshError, SshResult};
+use std::path::Path;
 
 impl Session {
-
     fn get_config(&self) -> SshResult<&Config> {
         if self.config.is_none() {
-            return Err(SshError::from("config is none."))
+            return Err(SshError::from("config is none."));
         }
         Ok(self.config.as_ref().unwrap())
     }
@@ -26,21 +25,24 @@ impl Session {
         self.auth_user_info(user_info);
     }
 
-    pub fn set_user_and_key_pair<U: ToString, K: ToString>(&mut self, username: U, key_str: K, key_type: KeyPairType) -> SshResult<()> {
+    pub fn set_user_and_key_pair<U: ToString, K: ToString>(
+        &mut self,
+        username: U,
+        key_str: K,
+        key_type: KeyPairType,
+    ) -> SshResult<()> {
         let pair = KeyPair::from_str(key_str.to_string().as_str(), key_type)?;
         let user_info = UserInfo::from_key_pair(username, pair);
         self.auth_user_info(user_info);
         Ok(())
     }
 
-    pub fn set_user_and_key_pair_path
-    <U: ToString, P: AsRef<Path>>
-    (&mut self,
-     username: U,
-     key_path: P,
-     key_type: KeyPairType)
-        -> SshResult<()>
-    {
+    pub fn set_user_and_key_pair_path<U: ToString, P: AsRef<Path>>(
+        &mut self,
+        username: U,
+        key_path: P,
+        key_type: KeyPairType,
+    ) -> SshResult<()> {
         let pair = KeyPair::from_path(key_path, key_type)?;
         let user_info = UserInfo::from_key_pair(username.to_string(), pair);
         self.auth_user_info(user_info);

--- a/src/slog.rs
+++ b/src/slog.rs
@@ -1,6 +1,4 @@
-
 pub use log;
-
 
 use log::{LevelFilter, Log, Metadata, Record};
 
@@ -8,13 +6,14 @@ pub(crate) static SLOG: Slog = Slog;
 
 pub struct Slog;
 
-
-
 impl Slog {
     pub fn init(level: LevelFilter) {
         if let Err(e) = log::set_logger(&SLOG) {
             // 重复设置日志记录
-            log::error!("initialization log error, the error information is: {:?}", e);
+            log::error!(
+                "initialization log error, the error information is: {:?}",
+                e
+            );
             return;
         }
         log::set_max_level(level);
@@ -24,8 +23,6 @@ impl Slog {
         Slog::init(LevelFilter::Trace)
     }
 }
-
-
 
 impl Log for Slog {
     fn enabled(&self, metadata: &Metadata) -> bool {

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,27 +1,24 @@
-use std::time::{Duration, SystemTime};
-use crate::{slog::log, SshError, SshResult};
 use crate::error::SshErrorKind;
+use crate::{slog::log, SshError, SshResult};
+use std::time::{Duration, SystemTime};
 
 pub(crate) struct Timeout {
     time: SystemTime,
-    timeout_sec: u64
+    timeout_sec: u64,
 }
 
 impl Timeout {
     pub(crate) fn new(timeout_sec: u64) -> Self {
         let time = SystemTime::now();
         let time = time + Duration::from_secs(timeout_sec);
-        Timeout {
-            time,
-            timeout_sec
-        }
+        Timeout { time, timeout_sec }
     }
 
     pub(crate) fn is_timeout(&self) -> SshResult<()> {
         let time = SystemTime::now();
         if time > self.time {
             log::error!("time out.");
-            return Err(SshError::from(SshErrorKind::Timeout))
+            return Err(SshError::from(SshErrorKind::Timeout));
         }
         Ok(())
     }

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -4,17 +4,16 @@ pub struct UserInfo {
     pub(crate) auth_type: AuthType,
     pub(crate) username: String,
     pub(crate) password: String,
-    pub(crate) key_pair: KeyPair
+    pub(crate) key_pair: KeyPair,
 }
 
 impl UserInfo {
-
     pub fn from_key_pair<S: ToString>(user_name: S, key_pair: KeyPair) -> Self {
         UserInfo {
             auth_type: AuthType::PublicKey,
             username: user_name.to_string(),
             password: "".to_string(),
-            key_pair
+            key_pair,
         }
     }
 
@@ -23,14 +22,12 @@ impl UserInfo {
             auth_type: AuthType::Password,
             username: user_name.to_string(),
             password: password.to_string(),
-            key_pair: KeyPair::new()
+            key_pair: KeyPair::new(),
         }
     }
-
 }
-
 
 pub enum AuthType {
     Password,
-    PublicKey
+    PublicKey,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,9 @@
-use std::str::FromStr;
-use std::time::{SystemTime, UNIX_EPOCH};
-use rand::Rng;
-use rand::rngs::OsRng;
 use crate::error::{SshError, SshResult};
 use crate::slog::log;
-
+use rand::rngs::OsRng;
+use rand::Rng;
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) fn from_utf8(v: Vec<u8>) -> SshResult<String> {
     match String::from_utf8(v) {
@@ -17,23 +16,21 @@ pub(crate) fn from_utf8(v: Vec<u8>) -> SshResult<String> {
     }
 }
 
-
 pub(crate) fn sys_time_to_secs(time: SystemTime) -> SshResult<u64> {
-     match time.duration_since(UNIX_EPOCH) {
+    match time.duration_since(UNIX_EPOCH) {
         Ok(t) => Ok(t.as_secs()),
-        Err(e) => {
-            Err(SshError::from(format!("SystemTimeError difference: {:?}", e.duration())))
-        }
+        Err(e) => Err(SshError::from(format!(
+            "SystemTimeError difference: {:?}",
+            e.duration()
+        ))),
     }
 }
-
 
 // 十六位随机数
 pub(crate) fn cookie() -> Vec<u8> {
     let cookie: [u8; 16] = OsRng.gen();
     cookie.to_vec()
 }
-
 
 #[allow(dead_code)]
 pub(crate) fn vec_u8_to_string(v: Vec<u8>, pat: &str) -> SshResult<Vec<String>> {
@@ -46,24 +43,18 @@ pub(crate) fn vec_u8_to_string(v: Vec<u8>, pat: &str) -> SshResult<Vec<String>> 
     Ok(vec)
 }
 
-
 #[allow(dead_code)]
 pub(crate) fn str_to_u32(v: &str) -> SshResult<u32> {
     match u32::from_str(v) {
         Ok(v) => Ok(v),
-        Err(_) => {
-            Err(SshError::from("str to u32 error"))
-        }
+        Err(_) => Err(SshError::from("str to u32 error")),
     }
 }
-
 
 #[allow(dead_code)]
 pub(crate) fn str_to_i64(v: &str) -> SshResult<i64> {
     match i64::from_str(v) {
         Ok(v) => Ok(v),
-        Err(_) => {
-            Err(SshError::from("str to i64 error"))
-        }
+        Err(_) => Err(SshError::from("str to i64 error")),
     }
 }

--- a/src/window_size.rs
+++ b/src/window_size.rs
@@ -106,19 +106,19 @@ impl WindowSize {
                 return Ok(())
             }
         }
-        return Ok(())
+        Ok(())
     }
 
     pub(crate) fn sub_remote_window_size(&mut self, rws: u32) {
-        self.remote_window_size = self.remote_window_size - rws;
+        self.remote_window_size -= rws;
     }
 
     pub(crate) fn add_remote_window_size(&mut self, rws: u32) {
-        self.remote_window_size = self.remote_window_size + rws;
+        self.remote_window_size += rws;
     }
 
     pub(crate) fn add_remote_max_window_size(&mut self, rws: u32) {
-        self.remote_max_window_size = self.remote_max_window_size + rws;
+        self.remote_max_window_size += rws;
     }
 }
 
@@ -135,7 +135,7 @@ impl WindowSize {
         };
         self.sub_local_window_size(size);
         let used = self.local_max_window_size - self.local_window_size;
-        if used <= 0 {
+        if used == 0 {
             return Ok(())
         }
         if (self.local_max_window_size / used) > 20 {
@@ -158,15 +158,15 @@ impl WindowSize {
             return Err(SshError::from(e))
         }
         self.add_local_window_size(used);
-        return Ok(());
+        Ok(())
     }
 
     pub(crate) fn sub_local_window_size(&mut self, lws: u32) {
-        self.local_window_size = self.local_window_size - lws;
+        self.local_window_size -= lws;
     }
 
     pub(crate) fn add_local_window_size(&mut self, lws: u32) {
-        self.local_window_size = self.local_window_size + lws;
+        self.local_window_size += lws;
     }
 
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,6 +1,1 @@
-mod tests {
-
-}
-
-
-
+mod tests {}


### PR DESCRIPTION
Hi there,

Actually, I'd like to build an ssh wasm application and found this crate, which is closest to what I need
But the problem is that wasm needs a websocket and in order not to break the existing logic, it needs to be asynchronous.
So I'm going to change this
```Rust
pub struct Client {
    pub(crate) stream: TcpStream,
    pub(crate) sequence: Sequence,
    pub(crate) timeout: Timeout,
    pub(crate) encryption: Option<Box<dyn Encryption>>,
    pub(crate) is_encryption: bool,
    pub(crate) session_id: Vec<u8>,
}
```
To 
```Rust
use tokio::io::{AsyncRead, AsyncWrite};

pub struct Client<S> 
where
    S: AsyncRead + AsyncWrite + Unpin,
{
    pub(crate) stream: S,
    pub(crate) sequence: Sequence,
    pub(crate) timeout: Timeout,
    pub(crate) encryption: Option<Box<dyn Encryption>>,
    pub(crate) is_encryption: bool,
    pub(crate) session_id: Vec<u8>,
}
```

Just like my own crate [vnc-rs](https://crates.io/crates/vnc-rs) does

But these changes seemed huge, so I decided to start with cargo clippy & fmt on the existing code while getting the tests for cargo all successful.

As fmt can be a real turn-off for code reviews, I made a separate commit of fmt and the other containing just the clippy results.
Hope this is helpful to you.

```Bash
$ cargo clippy --fix
    Checking ssh-rs v0.2.1 (/home/my/projects/ssh-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 1.77s
$ cargo test
   Compiling ssh-rs v0.2.1 (/home/my/projects/ssh-rs)
    Finished test [unoptimized + debuginfo] target(s) in 0.78s
     Running unittests src/lib.rs (target/debug/deps/ssh_rs-bd2d7b9dabb611b3)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ssh-rs

running 8 tests
test src/lib.rs - (line 9) - compile ... ok
test src/lib.rs - (line 49) - compile ... ok
test src/lib.rs - (line 33) - compile ... ok
test src/lib.rs - (line 21) - compile ... ok
test src/lib.rs - (line 137) - compile ... ok
test src/lib.rs - (line 103) - compile ... ok
test src/lib.rs - (line 84) - compile ... ok
test src/lib.rs - (line 65) - compile ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

BRs
