### PR TITLE
Add bio support to decouple the ssh client from std::net::TcpStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Gao Xiang Kang <1148118271@qq.com>"]
 description = "In addition to encryption library, pure RUST implementation of SSH-2.0 client protocol"

--- a/examples/bio/Cargo.toml
+++ b/examples/bio/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bio"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ssh-rs = { path = "../../" }

--- a/examples/bio/src/main.rs
+++ b/examples/bio/src/main.rs
@@ -1,0 +1,52 @@
+use ssh_rs::ssh;
+use std::net::{TcpStream, ToSocketAddrs};
+
+fn main() {
+    let mut session = ssh::create_session();
+    let bio = MyProxy::new("127.0.0.1:22");
+    session.set_user_and_password("ubuntu", "password");
+    session.connect_bio(bio).unwrap();
+    // Usage 1
+    let exec = session.open_exec().unwrap();
+    let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
+    println!("{}", String::from_utf8(vec).unwrap());
+    // Usage 2
+    let channel = session.open_channel().unwrap();
+    let exec = channel.open_exec().unwrap();
+    let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
+    println!("{}", String::from_utf8(vec).unwrap());
+    // Close session.
+    session.close().unwrap();
+}
+
+// Use a real ssh server since I don't wanna implement a ssh-server in the example codes
+struct MyProxy {
+    server: TcpStream,
+}
+
+impl MyProxy {
+    fn new<A>(addr: A) -> Self
+    where
+        A: ToSocketAddrs,
+    {
+        Self {
+            server: TcpStream::connect(addr).unwrap(),
+        }
+    }
+}
+
+impl std::io::Read for MyProxy {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.server.read(buf)
+    }
+}
+
+impl std::io::Write for MyProxy {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.server.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.server.flush()
+    }
+}

--- a/examples/exec/src/main.rs
+++ b/examples/exec/src/main.rs
@@ -1,11 +1,11 @@
-use ssh_rs::{ssh, ChannelExec};
+use ssh_rs::ssh;
 
 fn main() {
     let mut session = ssh::create_session();
     session.set_user_and_password("ubuntu", "password");
     session.connect("127.0.0.1:22").unwrap();
     // Usage 1
-    let exec: ChannelExec = session.open_exec().unwrap();
+    let exec = session.open_exec().unwrap();
     let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
     println!("{}", String::from_utf8(vec).unwrap());
     // Usage 2

--- a/examples/scp/src/main.rs
+++ b/examples/scp/src/main.rs
@@ -1,4 +1,4 @@
-use ssh_rs::{ssh, ChannelScp};
+use ssh_rs::ssh;
 
 fn main() {
     let mut session = ssh::create_session();
@@ -7,74 +7,74 @@ fn main() {
     // Usage 1
 
     // upload a file
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.upload("./src/main.rs", "./").unwrap();
     assert_file("/home/ubuntu/main.rs");
 
     // upload with a rename
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.upload("./src/main.rs", "./abc").unwrap();
     assert_file("/home/ubuntu/abc");
 
     // upload to an implicit dir
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.upload("./src/main.rs", "./test").unwrap();
     assert_file("/home/ubuntu/test/main.rs");
 
     // upload a dir
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.upload("./src", "./test").unwrap();
     assert_file("/home/ubuntu/test/src/main.rs");
     assert_file("/home/ubuntu/test/src");
 
     // upload a with a rename
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.upload("./src", "./crs").unwrap();
     assert_file("/home/ubuntu/crs/main.rs");
     assert_file("/home/ubuntu/crs");
 
     // download a file
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.download("./", "test/a").unwrap();
     assert_file("./a");
 
     // download with a rename
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.download("./b", "test/a").unwrap();
     assert_file("./b");
 
     // download to an implicit dir
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     let _ = std::fs::create_dir("dir");
     scp.download("./dir", "test/a").unwrap();
     assert_file("./dir/a");
     assert_file("./dir");
 
     // download a dir
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.download("./", "test").unwrap();
     assert_file("./test/a");
     assert_file("./test");
 
     // download with a rename
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.download("./dir2", "test").unwrap();
     assert_file("./dir2/a");
     assert_file("./dir2");
 
     // download with a rename #2
-    let scp: ChannelScp = session.open_scp().unwrap();
+    let scp = session.open_scp().unwrap();
     scp.download("./dir2/", "test").unwrap();
     assert_file("./dir2/a");
     assert_file("./dir2");
 
     // Usage 2
     // let channel: Channel = session.open_channel().unwrap();
-    // let scp: ChannelScp = channel.open_scp().unwrap();
+    // let scp = channel.open_scp().unwrap();
     // scp.upload("local path", "remote path").unwrap();
 
     // let channel: Channel = session.open_channel().unwrap();
-    // let scp: ChannelScp = channel.open_scp().unwrap();
+    // let scp = channel.open_scp().unwrap();
     // scp.download("local path", "remote path").unwrap();
 
     session.close().unwrap();

--- a/examples/shell/src/main.rs
+++ b/examples/shell/src/main.rs
@@ -1,4 +1,4 @@
-use ssh_rs::{ssh, Channel, ChannelShell};
+use ssh_rs::{ssh, ChannelShell};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -10,7 +10,7 @@ fn main() {
     let mut shell = session.open_shell().unwrap();
     run_shell(&mut shell);
     // Usage 2
-    let channel: Channel = session.open_channel().unwrap();
+    let channel = session.open_channel().unwrap();
     let mut shell = channel.open_shell().unwrap();
     run_shell(&mut shell);
     // Close channel.
@@ -19,7 +19,7 @@ fn main() {
     session.close().unwrap();
 }
 
-fn run_shell(shell: &mut ChannelShell) {
+fn run_shell(shell: &mut ChannelShell<std::net::TcpStream>) {
     sleep(Duration::from_millis(500));
     let vec = shell.read().unwrap();
     println!("{}", String::from_utf8(vec).unwrap());

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -12,19 +12,19 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-pub struct Channel<IO>
+pub struct Channel<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     pub(crate) remote_close: bool,
     pub(crate) local_close: bool,
     pub(crate) window_size: WindowSize,
-    pub(crate) session: *mut Session<IO>,
+    pub(crate) session: *mut Session<S>,
 }
 
-impl<IO> Deref for Channel<IO>
+impl<S> Deref for Channel<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     type Target = WindowSize;
 
@@ -33,18 +33,18 @@ where
     }
 }
 
-impl<IO> DerefMut for Channel<IO>
+impl<S> DerefMut for Channel<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.window_size
     }
 }
 
-impl<IO> Channel<IO>
+impl<S> Channel<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     pub(crate) fn other(&mut self, message_code: u8, mut result: Data) -> SshResult<()> {
         match message_code {
@@ -80,17 +80,17 @@ where
         Ok(())
     }
 
-    pub fn open_shell(self) -> SshResult<ChannelShell<IO>> {
+    pub fn open_shell(self) -> SshResult<ChannelShell<S>> {
         log::info!("shell opened.");
         ChannelShell::open(self)
     }
 
-    pub fn open_exec(self) -> SshResult<ChannelExec<IO>> {
+    pub fn open_exec(self) -> SshResult<ChannelExec<S>> {
         log::info!("exec opened.");
         Ok(ChannelExec::open(self))
     }
 
-    pub fn open_scp(self) -> SshResult<ChannelScp<IO>> {
+    pub fn open_scp(self) -> SshResult<ChannelScp<S>> {
         log::info!("scp opened.");
         Ok(ChannelScp::open(self))
     }
@@ -141,7 +141,7 @@ where
     }
 
     #[allow(clippy::mut_from_ref)]
-    pub(crate) fn get_session_mut(&self) -> &mut Session<IO> {
+    pub(crate) fn get_session_mut(&self) -> &mut Session<S> {
         unsafe { &mut *self.session }
     }
 

--- a/src/channel_exec.rs
+++ b/src/channel_exec.rs
@@ -5,13 +5,13 @@ use crate::constant::{ssh_msg_code, ssh_str};
 use crate::data::Data;
 use crate::error::SshResult;
 
-pub struct ChannelExec<IO: Read + Write>(pub(crate) Channel<IO>);
+pub struct ChannelExec<S: Read + Write>(pub(crate) Channel<S>);
 
-impl<IO> ChannelExec<IO>
+impl<S> ChannelExec<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
-    pub(crate) fn open(channel: Channel<IO>) -> Self {
+    pub(crate) fn open(channel: Channel<S>) -> Self {
         ChannelExec(channel)
     }
 

--- a/src/channel_exec.rs
+++ b/src/channel_exec.rs
@@ -1,12 +1,17 @@
+use std::io::{Read, Write};
+
 use crate::channel::Channel;
 use crate::constant::{ssh_msg_code, ssh_str};
 use crate::data::Data;
 use crate::error::SshResult;
 
-pub struct ChannelExec(pub(crate) Channel);
+pub struct ChannelExec<IO: Read + Write>(pub(crate) Channel<IO>);
 
-impl ChannelExec {
-    pub(crate) fn open(channel: Channel) -> Self {
+impl<IO> ChannelExec<IO>
+where
+    IO: Read + Write,
+{
+    pub(crate) fn open(channel: Channel<IO>) -> Self {
         ChannelExec(channel)
     }
 

--- a/src/channel_scp.rs
+++ b/src/channel_scp.rs
@@ -2,16 +2,25 @@ use crate::constant::{scp, ssh_msg_code, ssh_str};
 use crate::data::Data;
 use crate::error::{SshError, SshResult};
 use crate::Channel;
-use std::borrow::BorrowMut;
 use std::path::{Path, PathBuf};
+use std::{
+    borrow::BorrowMut,
+    io::{Read, Write},
+};
 
-pub struct ChannelScp {
-    pub(crate) channel: Channel,
+pub struct ChannelScp<IO>
+where
+    IO: Read + Write,
+{
+    pub(crate) channel: Channel<IO>,
     pub(crate) local_path: PathBuf,
 }
 
-impl ChannelScp {
-    pub(crate) fn open(channel: Channel) -> Self {
+impl<IO> ChannelScp<IO>
+where
+    IO: Read + Write,
+{
+    pub(crate) fn open(channel: Channel<IO>) -> Self {
         ChannelScp {
             channel,
             local_path: Default::default(),

--- a/src/channel_scp.rs
+++ b/src/channel_scp.rs
@@ -8,19 +8,19 @@ use std::{
     io::{Read, Write},
 };
 
-pub struct ChannelScp<IO>
+pub struct ChannelScp<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
-    pub(crate) channel: Channel<IO>,
+    pub(crate) channel: Channel<S>,
     pub(crate) local_path: PathBuf,
 }
 
-impl<IO> ChannelScp<IO>
+impl<S> ChannelScp<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
-    pub(crate) fn open(channel: Channel<IO>) -> Self {
+    pub(crate) fn open(channel: Channel<S>) -> Self {
         ChannelScp {
             channel,
             local_path: Default::default(),

--- a/src/channel_scp_d.rs
+++ b/src/channel_scp_d.rs
@@ -3,13 +3,16 @@ use crate::constant::{scp, ssh_msg_code};
 use crate::error::{SshError, SshResult};
 use crate::slog::log;
 use crate::util;
-use std::ffi::OsStr;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
+use std::{ffi::OsStr, io::Read};
 
-impl ChannelScp {
+impl<IO> ChannelScp<IO>
+where
+    IO: Read + Write,
+{
     ///   download
     pub fn download<S: AsRef<OsStr> + ?Sized>(
         mut self,

--- a/src/channel_scp_d.rs
+++ b/src/channel_scp_d.rs
@@ -9,15 +9,15 @@ use std::io::Write;
 use std::path::Path;
 use std::{ffi::OsStr, io::Read};
 
-impl<IO> ChannelScp<IO>
+impl<S> ChannelScp<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     ///   download
-    pub fn download<S: AsRef<OsStr> + ?Sized>(
+    pub fn download<P: AsRef<OsStr> + ?Sized>(
         mut self,
-        local_path: &S,
-        remote_path: &S,
+        local_path: &P,
+        remote_path: &P,
     ) -> SshResult<()> {
         let local_path = Path::new(local_path);
         let remote_path = Path::new(remote_path);

--- a/src/channel_scp_u.rs
+++ b/src/channel_scp_u.rs
@@ -3,13 +3,16 @@ use crate::constant::{permission, scp};
 use crate::error::{SshError, SshResult};
 use crate::slog::log;
 use crate::util;
-use std::ffi::OsStr;
 use std::fs::{read_dir, File};
 use std::io::Read;
 use std::path::Path;
 use std::time::SystemTime;
+use std::{ffi::OsStr, io::Write};
 
-impl ChannelScp {
+impl<IO> ChannelScp<IO>
+where
+    IO: Read + Write,
+{
     pub fn upload<S: AsRef<OsStr> + ?Sized>(
         mut self,
         local_path: &S,

--- a/src/channel_scp_u.rs
+++ b/src/channel_scp_u.rs
@@ -9,14 +9,14 @@ use std::path::Path;
 use std::time::SystemTime;
 use std::{ffi::OsStr, io::Write};
 
-impl<IO> ChannelScp<IO>
+impl<S> ChannelScp<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
-    pub fn upload<S: AsRef<OsStr> + ?Sized>(
+    pub fn upload<P: AsRef<OsStr> + ?Sized>(
         mut self,
-        local_path: &S,
-        remote_path: &S,
+        local_path: &P,
+        remote_path: &P,
     ) -> SshResult<()> {
         let local_path = Path::new(local_path);
         let remote_path = Path::new(remote_path);

--- a/src/channel_shell.rs
+++ b/src/channel_shell.rs
@@ -5,13 +5,13 @@ use crate::constant::{ssh_msg_code, ssh_str};
 use crate::data::Data;
 use crate::error::SshResult;
 
-pub struct ChannelShell<IO: Read + Write>(pub(crate) Channel<IO>);
+pub struct ChannelShell<S: Read + Write>(pub(crate) Channel<S>);
 
-impl<IO> ChannelShell<IO>
+impl<S> ChannelShell<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
-    pub(crate) fn open(mut channel: Channel<IO>) -> SshResult<Self> {
+    pub(crate) fn open(mut channel: Channel<S>) -> SshResult<Self> {
         // shell 形式需要一个伪终端
         ChannelShell::request_pty(&channel)?;
         ChannelShell::get_shell(&channel)?;
@@ -30,7 +30,7 @@ where
         }
     }
 
-    fn request_pty(channel: &Channel<IO>) -> SshResult<()> {
+    fn request_pty(channel: &Channel<S>) -> SshResult<()> {
         let mut data = Data::new();
         data.put_u8(ssh_msg_code::SSH_MSG_CHANNEL_REQUEST)
             .put_u32(channel.server_channel_no)
@@ -57,7 +57,7 @@ where
             .write(data)
     }
 
-    fn get_shell(channel: &Channel<IO>) -> SshResult<()> {
+    fn get_shell(channel: &Channel<S>) -> SshResult<()> {
         let mut data = Data::new();
         data.put_u8(ssh_msg_code::SSH_MSG_CHANNEL_REQUEST)
             .put_u32(channel.server_channel_no)

--- a/src/channel_shell.rs
+++ b/src/channel_shell.rs
@@ -1,12 +1,17 @@
+use std::io::{Read, Write};
+
 use crate::channel::Channel;
 use crate::constant::{ssh_msg_code, ssh_str};
 use crate::data::Data;
 use crate::error::SshResult;
 
-pub struct ChannelShell(pub(crate) Channel);
+pub struct ChannelShell<IO: Read + Write>(pub(crate) Channel<IO>);
 
-impl ChannelShell {
-    pub(crate) fn open(mut channel: Channel) -> SshResult<Self> {
+impl<IO> ChannelShell<IO>
+where
+    IO: Read + Write,
+{
+    pub(crate) fn open(mut channel: Channel<IO>) -> SshResult<Self> {
         // shell 形式需要一个伪终端
         ChannelShell::request_pty(&channel)?;
         ChannelShell::get_shell(&channel)?;
@@ -25,7 +30,7 @@ impl ChannelShell {
         }
     }
 
-    fn request_pty(channel: &Channel) -> SshResult<()> {
+    fn request_pty(channel: &Channel<IO>) -> SshResult<()> {
         let mut data = Data::new();
         data.put_u8(ssh_msg_code::SSH_MSG_CHANNEL_REQUEST)
             .put_u32(channel.server_channel_no)
@@ -52,7 +57,7 @@ impl ChannelShell {
             .write(data)
     }
 
-    fn get_shell(channel: &Channel) -> SshResult<()> {
+    fn get_shell(channel: &Channel<IO>) -> SshResult<()> {
         let mut data = Data::new();
         data.put_u8(ssh_msg_code::SSH_MSG_CHANNEL_REQUEST)
             .put_u32(channel.server_channel_no)

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,11 +8,11 @@ use crate::user_info::UserInfo;
 use std::io::{self, Read, Write};
 use std::ops::{Deref, DerefMut};
 
-pub struct Client<IO>
+pub struct Client<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
-    pub(crate) stream: IO,
+    pub(crate) stream: S,
     pub(crate) sequence: Sequence,
     pub(crate) timeout: Timeout,
     pub(crate) config: Config,
@@ -49,15 +49,15 @@ impl Sequence {
     }
 }
 
-impl<IO> Client<IO>
+impl<S> Client<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     pub(crate) fn connect(
-        stream: IO,
+        stream: S,
         timeout_sec: u64,
         user_info: UserInfo,
-    ) -> SshResult<Client<IO>> {
+    ) -> SshResult<Client<S>> {
         Ok(Client {
             stream,
             sequence: Sequence {
@@ -107,29 +107,29 @@ where
     }
 }
 
-impl<IO> Drop for Client<IO>
+impl<S> Drop for Client<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     fn drop(&mut self) {
         log::info!("client close");
     }
 }
 
-impl<IO> Deref for Client<IO>
+impl<S> Deref for Client<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
-    type Target = IO;
+    type Target = S;
 
     fn deref(&self) -> &Self::Target {
         &self.stream
     }
 }
 
-impl<IO> DerefMut for Client<IO>
+impl<S> DerefMut for Client<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.stream

--- a/src/client_r.rs
+++ b/src/client_r.rs
@@ -8,10 +8,12 @@ use crate::h::H;
 use crate::packet::Packet;
 use crate::window_size::WindowSize;
 use crate::{kex, SshError, SshResult};
-use std::io;
-use std::io::Read;
+use std::io::{self, Read, Write};
 
-impl Client {
+impl<IO> Client<IO>
+where
+    IO: Read + Write,
+{
     /// 发送客户端版本
     pub(crate) fn read_version(&mut self) -> Vec<u8> {
         let mut v = [0_u8; 128];
@@ -47,7 +49,7 @@ impl Client {
                 len
             }
             Err(e) => {
-                if Client::is_would_block(&e) {
+                if Client::<IO>::is_would_block(&e) {
                     return Ok(results);
                 }
                 return Err(SshError::from(e));

--- a/src/client_r.rs
+++ b/src/client_r.rs
@@ -10,9 +10,9 @@ use crate::window_size::WindowSize;
 use crate::{kex, SshError, SshResult};
 use std::io::{self, Read, Write};
 
-impl<IO> Client<IO>
+impl<S> Client<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     /// 发送客户端版本
     pub(crate) fn read_version(&mut self) -> Vec<u8> {
@@ -49,7 +49,7 @@ where
                 len
             }
             Err(e) => {
-                if Client::<IO>::is_would_block(&e) {
+                if Client::<S>::is_would_block(&e) {
                     return Ok(results);
                 }
                 return Err(SshError::from(e));

--- a/src/client_w.rs
+++ b/src/client_w.rs
@@ -5,9 +5,9 @@ use crate::window_size::WindowSize;
 use crate::{constant, h::H, kex, SshError, SshResult};
 use std::io::{Read, Write};
 
-impl<IO> Client<IO>
+impl<S> Client<S>
 where
-    IO: Write + Read,
+    S: Read + Write,
 {
     /// 发送客户端版本
     pub(crate) fn write_version(&mut self, buf: &[u8]) -> SshResult<()> {
@@ -42,7 +42,7 @@ where
         self.sequence.client_auto_increment();
         loop {
             if let Err(e) = self.stream.write(&buf) {
-                if Client::<IO>::is_would_block(&e) {
+                if Client::<S>::is_would_block(&e) {
                     self.timeout.is_timeout()?;
                     continue;
                 }

--- a/src/client_w.rs
+++ b/src/client_w.rs
@@ -3,9 +3,12 @@ use crate::data::Data;
 use crate::packet::Packet;
 use crate::window_size::WindowSize;
 use crate::{constant, h::H, kex, SshError, SshResult};
-use std::io::Write;
+use std::io::{Read, Write};
 
-impl Client {
+impl<IO> Client<IO>
+where
+    IO: Write + Read,
+{
     /// 发送客户端版本
     pub(crate) fn write_version(&mut self, buf: &[u8]) -> SshResult<()> {
         self.w_size += buf.len();
@@ -39,7 +42,7 @@ impl Client {
         self.sequence.client_auto_increment();
         loop {
             if let Err(e) = self.stream.write(&buf) {
-                if Client::is_would_block(&e) {
+                if Client::<IO>::is_would_block(&e) {
                     self.timeout.is_timeout()?;
                     continue;
                 }

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -1,3 +1,5 @@
+use std::io::{Read, Write};
+
 use crate::algorithm::hash;
 use crate::algorithm::key_exchange::KeyExchange;
 use crate::algorithm::public_key::PublicKey;
@@ -13,11 +15,14 @@ use crate::window_size::WindowSize;
 use crate::{client::Client, h::H, util};
 
 /// 发送客户端的算法列表
-pub(crate) fn send_algorithm(
+pub(crate) fn send_algorithm<IO>(
     h: &mut H,
-    client: &mut Client,
+    client: &mut Client<IO>,
     rws: Option<&mut WindowSize>,
-) -> SshResult<()> {
+) -> SshResult<()>
+where
+    IO: Read + Write,
+{
     log::info!(
         "client algorithms: [{}]",
         client.config.algorithm.client_algorithm.to_string()
@@ -40,11 +45,14 @@ pub(crate) fn send_algorithm(
 }
 
 /// 获取服务端的算法列表
-pub(crate) fn receive_algorithm(
+pub(crate) fn receive_algorithm<IO>(
     h: &mut H,
-    client: &mut Client,
+    client: &mut Client<IO>,
     mut rws: Option<&mut WindowSize>,
-) -> SshResult<()> {
+) -> SshResult<()>
+where
+    IO: Read + Write,
+{
     loop {
         let results = match &mut rws {
             None => client.read()?,
@@ -89,11 +97,14 @@ pub(crate) fn processing_server_algorithm(config: &mut Config, mut data: Data) -
 }
 
 /// 发送客户端公钥
-pub(crate) fn send_qc(
-    client: &mut Client,
+pub(crate) fn send_qc<IO>(
+    client: &mut Client<IO>,
     public_key: &[u8],
     rws: Option<&mut WindowSize>,
-) -> SshResult<()> {
+) -> SshResult<()>
+where
+    IO: Read + Write,
+{
     let mut data = Data::new();
     data.put_u8(ssh_msg_code::SSH_MSG_KEXDH_INIT);
     data.put_u8s(public_key);
@@ -104,13 +115,16 @@ pub(crate) fn send_qc(
 }
 
 /// 接收服务端公钥和签名，并验证签名的正确性
-pub(crate) fn verify_signature_and_new_keys(
-    client: &mut Client,
+pub(crate) fn verify_signature_and_new_keys<IO>(
+    client: &mut Client<IO>,
     public_key: &mut Box<dyn PublicKey>,
     key_exchange: &mut Box<dyn KeyExchange>,
     h: &mut H,
     mut rws: Option<&mut WindowSize>,
-) -> SshResult<Vec<u8>> {
+) -> SshResult<Vec<u8>>
+where
+    IO: Read + Write,
+{
     let mut session_id = vec![];
     loop {
         let results = match &mut rws {
@@ -170,7 +184,13 @@ pub(crate) fn generate_signature(
 }
 
 /// SSH_MSG_NEWKEYS 代表密钥交换完成
-pub(crate) fn new_keys(client: &mut Client, rws: Option<&mut WindowSize>) -> Result<(), SshError> {
+pub(crate) fn new_keys<IO>(
+    client: &mut Client<IO>,
+    rws: Option<&mut WindowSize>,
+) -> Result<(), SshError>
+where
+    IO: Read + Write,
+{
     let mut data = Data::new();
     data.put_u8(ssh_msg_code::SSH_MSG_NEWKEYS);
     match rws {
@@ -181,11 +201,14 @@ pub(crate) fn new_keys(client: &mut Client, rws: Option<&mut WindowSize>) -> Res
     Ok(())
 }
 
-pub(crate) fn key_agreement(
+pub(crate) fn key_agreement<IO>(
     h: &mut H,
-    client: &mut Client,
+    client: &mut Client<IO>,
     mut rws: Option<&mut WindowSize>,
-) -> SshResult<hash::HashType> {
+) -> SshResult<hash::HashType>
+where
+    IO: Read + Write,
+{
     log::info!("start for key negotiation.");
     log::info!("send client algorithm list.");
     match &mut rws {

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -15,13 +15,13 @@ use crate::window_size::WindowSize;
 use crate::{client::Client, h::H, util};
 
 /// 发送客户端的算法列表
-pub(crate) fn send_algorithm<IO>(
+pub(crate) fn send_algorithm<S>(
     h: &mut H,
-    client: &mut Client<IO>,
+    client: &mut Client<S>,
     rws: Option<&mut WindowSize>,
 ) -> SshResult<()>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     log::info!(
         "client algorithms: [{}]",
@@ -45,13 +45,13 @@ where
 }
 
 /// 获取服务端的算法列表
-pub(crate) fn receive_algorithm<IO>(
+pub(crate) fn receive_algorithm<S>(
     h: &mut H,
-    client: &mut Client<IO>,
+    client: &mut Client<S>,
     mut rws: Option<&mut WindowSize>,
 ) -> SshResult<()>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     loop {
         let results = match &mut rws {
@@ -97,13 +97,13 @@ pub(crate) fn processing_server_algorithm(config: &mut Config, mut data: Data) -
 }
 
 /// 发送客户端公钥
-pub(crate) fn send_qc<IO>(
-    client: &mut Client<IO>,
+pub(crate) fn send_qc<S>(
+    client: &mut Client<S>,
     public_key: &[u8],
     rws: Option<&mut WindowSize>,
 ) -> SshResult<()>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     let mut data = Data::new();
     data.put_u8(ssh_msg_code::SSH_MSG_KEXDH_INIT);
@@ -115,15 +115,15 @@ where
 }
 
 /// 接收服务端公钥和签名，并验证签名的正确性
-pub(crate) fn verify_signature_and_new_keys<IO>(
-    client: &mut Client<IO>,
+pub(crate) fn verify_signature_and_new_keys<S>(
+    client: &mut Client<S>,
     public_key: &mut Box<dyn PublicKey>,
     key_exchange: &mut Box<dyn KeyExchange>,
     h: &mut H,
     mut rws: Option<&mut WindowSize>,
 ) -> SshResult<Vec<u8>>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     let mut session_id = vec![];
     loop {
@@ -184,12 +184,12 @@ pub(crate) fn generate_signature(
 }
 
 /// SSH_MSG_NEWKEYS 代表密钥交换完成
-pub(crate) fn new_keys<IO>(
-    client: &mut Client<IO>,
+pub(crate) fn new_keys<S>(
+    client: &mut Client<S>,
     rws: Option<&mut WindowSize>,
 ) -> Result<(), SshError>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     let mut data = Data::new();
     data.put_u8(ssh_msg_code::SSH_MSG_NEWKEYS);
@@ -201,13 +201,13 @@ where
     Ok(())
 }
 
-pub(crate) fn key_agreement<IO>(
+pub(crate) fn key_agreement<S>(
     h: &mut H,
-    client: &mut Client<IO>,
+    client: &mut Client<S>,
     mut rws: Option<&mut WindowSize>,
 ) -> SshResult<hash::HashType>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     log::info!("start for key negotiation.");
     log::info!("send client algorithm list.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,9 +255,9 @@ pub mod ssh {
     use crate::slog::Slog;
     use crate::Session;
 
-    pub fn create_session<IO>() -> Session<IO>
+    pub fn create_session<S>() -> Session<S>
     where
-        IO: Read + Write,
+        S: Read + Write,
     {
         Session {
             timeout_sec: 30,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,10 +195,15 @@ pub use user_info::UserInfo;
 use crate::error::{SshError, SshResult};
 
 pub mod ssh {
+    use std::io::{Read, Write};
+
     use crate::slog::Slog;
     use crate::Session;
 
-    pub fn create_session() -> Session {
+    pub fn create_session<IO>() -> Session<IO>
+    where
+        IO: Read + Write,
+    {
         Session {
             timeout_sec: 30,
             user_info: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@
 //!
 //! ### 1. Password:
 //! ```no_run
-//! use ssh_rs::{Session, ssh};
+//! use ssh_rs::ssh;
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session = ssh::create_session();
 //! session.set_user_and_password("user", "password");
 //! session.connect("ip:port").unwrap();
 //! ```
@@ -19,10 +19,10 @@
 //!
 //! #### 1. Use key file path：
 //! ```no_run
-//! use ssh_rs::{Session, ssh};
+//! use ssh_rs::ssh;
 //! use ssh_rs::key_pair::KeyPairType;
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session = ssh::create_session();
 //! // pem format key path -> /xxx/xxx/id_rsa
 //! // KeyPairType::SshRsa -> Rsa type algorithm, currently only supports rsa.
 //! session.set_user_and_key_pair_path("user", "pem format key path", KeyPairType::SshRsa).unwrap();
@@ -31,10 +31,10 @@
 //!
 //! #### 2. Use key string：
 //! ```no_run
-//! use ssh_rs::{Session, ssh};
+//! use ssh_rs::ssh;
 //! use ssh_rs::key_pair::KeyPairType;
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session = ssh::create_session();
 //! // pem format key string:
 //! //      -----BEGIN RSA PRIVATE KEY-----
 //! //          xxxxxxxxxxxxxxxxxxxxx
@@ -47,14 +47,14 @@
 //! ## Enable global logging：
 //!
 //! ```no_run
-//! use ssh_rs::{Session, ssh};
+//! use ssh_rs::ssh;
 //!
 //! // is_enable_log Whether to enable global logging
 //! // The default is false(Do not enable)
 //! // Can be set as true (enable)
 //! ssh::is_enable_log(true);
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session = ssh::create_session();
 //! session.set_user_and_password("user", "password");
 //! session.connect("ip:port").unwrap();
 //! ```
@@ -63,9 +63,9 @@
 //! ## Set timeout：
 //!
 //! ```no_run
-//! use ssh_rs::{Session, ssh};
+//! use ssh_rs::ssh;
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session = ssh::create_session();
 //! // set_timeout
 //! // The unit is seconds
 //! // The default timeout is 30 seconds
@@ -82,11 +82,11 @@
 //! ### 1. exec
 //!
 //! ```no_run
-//! use ssh_rs::{ChannelExec, Session, ssh};
+//! use ssh_rs::{Session, ssh};
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session: Session<std::net::TcpStream> = ssh::create_session();
 //! // Usage 1
-//! let exec: ChannelExec = session.open_exec().unwrap();
+//! let exec = session.open_exec().unwrap();
 //! let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
 //! println!("{}", String::from_utf8(vec).unwrap());
 //! // Usage 2
@@ -103,14 +103,14 @@
 //! ```no_run
 //! use std::thread::sleep;
 //! use std::time::Duration;
-//! use ssh_rs::{Channel, ChannelShell, Session, ssh};
+//! use ssh_rs::{ChannelShell, ssh};
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session = ssh::create_session();
 //! // Usage 1
-//! let mut shell: ChannelShell = session.open_shell().unwrap();
+//! let mut shell = session.open_shell().unwrap();
 //! run_shell(&mut shell);
 //! // Usage 2
-//! let channel: Channel = session.open_channel().unwrap();
+//! let channel = session.open_channel().unwrap();
 //! let mut shell = channel.open_shell().unwrap();
 //! run_shell(&mut shell);
 //! // Close channel.
@@ -118,7 +118,7 @@
 //! // Close session.
 //! session.close().unwrap();
 //!
-//! fn run_shell(shell: &mut ChannelShell) {
+//! fn run_shell(shell: &mut ChannelShell<std::net::TcpStream>) {
 //!     sleep(Duration::from_millis(500));
 //!     let vec = shell.read().unwrap();
 //!     println!("{}", String::from_utf8(vec).unwrap());
@@ -135,23 +135,23 @@
 //! ### 3. scp
 //!
 //! ```no_run
-//! use ssh_rs::{Channel, ChannelScp, Session, ssh};
+//! use ssh_rs::{Session, ssh};
 //!
-//! let mut session: Session = ssh::create_session();
+//! let mut session: Session<std::net::TcpStream> = ssh::create_session();
 //! // Usage 1
-//! let scp: ChannelScp = session.open_scp().unwrap();
+//! let scp = session.open_scp().unwrap();
 //! scp.upload("local path", "remote path").unwrap();
 //!
-//! let scp: ChannelScp = session.open_scp().unwrap();
+//! let scp = session.open_scp().unwrap();
 //! scp.download("local path", "remote path").unwrap();
 //!
 //! // Usage 2
-//! let channel: Channel = session.open_channel().unwrap();
-//! let scp: ChannelScp = channel.open_scp().unwrap();
+//! let channel = session.open_channel().unwrap();
+//! let scp = channel.open_scp().unwrap();
 //! scp.upload("local path", "remote path").unwrap();
 //!
-//! let channel: Channel = session.open_channel().unwrap();
-//! let scp: ChannelScp = channel.open_scp().unwrap();
+//! let channel = session.open_channel().unwrap();
+//! let scp = channel.open_scp().unwrap();
 //! scp.download("local path", "remote path").unwrap();
 //!
 //! session.close().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,61 @@
 //! session.close().unwrap();
 //!
 //! ```
+//! 
+//! ### 4.bio
+//! 
+//! ```no_run
+//! use ssh_rs::ssh;
+//! use std::net::{TcpStream, ToSocketAddrs};
+//! 
+//! let mut session = ssh::create_session();
+//! let bio = MyProxy::new("127.0.0.1:22");
+//! session.set_user_and_password("ubuntu", "password");
+//! session.connect_bio(bio).unwrap();
+//! // Usage 1
+//! let exec = session.open_exec().unwrap();
+//! let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
+//! println!("{}", String::from_utf8(vec).unwrap());
+//! // Usage 2
+//! let channel = session.open_channel().unwrap();
+//! let exec = channel.open_exec().unwrap();
+//! let vec: Vec<u8> = exec.send_command("ls -all").unwrap();
+//! println!("{}", String::from_utf8(vec).unwrap());
+//! // Close session.
+//! session.close().unwrap();
+//! 
+//! // Use a real ssh server since I don't wanna implement a ssh-server in the example codes
+//! struct MyProxy {
+//!     server: TcpStream,
+//! }
+//! 
+//! impl MyProxy {
+//!     fn new<A>(addr: A) -> Self
+//!     where
+//!         A: ToSocketAddrs,
+//!     {
+//!         Self {
+//!             server: TcpStream::connect(addr).unwrap(),
+//!         }
+//!     }
+//! }
+//! 
+//! impl std::io::Read for MyProxy {
+//!     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+//!         self.server.read(buf)
+//!     }
+//! }
+//! 
+//! impl std::io::Write for MyProxy {
+//!     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+//!         self.server.write(buf)
+//!     }
+//! 
+//!     fn flush(&mut self) -> std::io::Result<()> {
+//!         self.server.flush()
+//!     }
+//! }
+//! 
 
 mod algorithm;
 mod channel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,13 +157,13 @@
 //! session.close().unwrap();
 //!
 //! ```
-//! 
+//!
 //! ### 4.bio
-//! 
+//!
 //! ```no_run
 //! use ssh_rs::ssh;
 //! use std::net::{TcpStream, ToSocketAddrs};
-//! 
+//!
 //! let mut session = ssh::create_session();
 //! let bio = MyProxy::new("127.0.0.1:22");
 //! session.set_user_and_password("ubuntu", "password");
@@ -179,12 +179,12 @@
 //! println!("{}", String::from_utf8(vec).unwrap());
 //! // Close session.
 //! session.close().unwrap();
-//! 
+//!
 //! // Use a real ssh server since I don't wanna implement a ssh-server in the example codes
 //! struct MyProxy {
 //!     server: TcpStream,
 //! }
-//! 
+//!
 //! impl MyProxy {
 //!     fn new<A>(addr: A) -> Self
 //!     where
@@ -195,23 +195,23 @@
 //!         }
 //!     }
 //! }
-//! 
+//!
 //! impl std::io::Read for MyProxy {
 //!     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
 //!         self.server.read(buf)
 //!     }
 //! }
-//! 
+//!
 //! impl std::io::Write for MyProxy {
 //!     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
 //!         self.server.write(buf)
 //!     }
-//! 
+//!
 //!     fn flush(&mut self) -> std::io::Result<()> {
 //!         self.server.flush()
 //!     }
 //! }
-//! 
+//!
 
 mod algorithm;
 mod channel;

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,23 +10,25 @@ use crate::user_info::AuthType;
 use crate::user_info::UserInfo;
 use crate::window_size::WindowSize;
 use crate::{Channel, ChannelExec, ChannelScp, ChannelShell};
-use std::net::ToSocketAddrs;
+use std::{
+    io::{Read, Write},
+    net::{TcpStream, ToSocketAddrs},
+};
 
-pub struct Session {
+pub struct Session<IO>
+where
+    IO: Read + Write,
+{
     pub(crate) timeout_sec: u64,
 
     pub(crate) user_info: Option<UserInfo>,
 
-    pub(crate) client: Option<Client>,
+    pub(crate) client: Option<Client<IO>>,
 
     pub(crate) client_channel_no: u32,
 }
 
-impl Session {
-    pub fn set_timeout(&mut self, secs: u64) {
-        self.timeout_sec = secs;
-    }
-
+impl Session<TcpStream> {
     pub fn connect<A>(&mut self, addr: A) -> SshResult<()>
     where
         A: ToSocketAddrs,
@@ -35,13 +37,38 @@ impl Session {
             return Err(SshError::from("user info is none."));
         }
         // 建立通道
-        self.client = Some(Client::connect(
-            addr,
+        let tcp = TcpStream::connect(addr)?;
+        // default nonblocking
+        tcp.set_nonblocking(true).unwrap();
+
+        log::info!("session opened.");
+        self.connect_bio(tcp)
+    }
+}
+
+impl<IO> Session<IO>
+where
+    IO: Read + Write,
+{
+    pub fn set_timeout(&mut self, secs: u64) {
+        self.timeout_sec = secs;
+    }
+
+    pub fn connect_bio(&mut self, stream: IO) -> SshResult<()> {
+        if self.user_info.is_none() {
+            return Err(SshError::from("user info is none."));
+        }
+        // 建立通道
+        self.client = Some(Client::<IO>::connect(
+            stream,
             self.timeout_sec,
             self.user_info.clone().unwrap(),
         )?);
         log::info!("session opened.");
+        self.post_connect()
+    }
 
+    fn post_connect(&mut self) -> SshResult<()> {
         let mut h = H::new();
         let client = self.client.as_mut().unwrap();
 
@@ -60,8 +87,11 @@ impl Session {
     }
 }
 
-impl Session {
-    pub fn open_channel(&mut self) -> SshResult<Channel> {
+impl<IO> Session<IO>
+where
+    IO: Read + Write,
+{
+    pub fn open_channel(&mut self) -> SshResult<Channel<IO>> {
         log::info!("channel opened.");
         self.send_open_channel(self.client_channel_no)?;
         let (server_channel_no, rws) = self.receive_open_channel()?;
@@ -77,27 +107,30 @@ impl Session {
             remote_close: false,
             local_close: false,
             window_size: win_size,
-            session: self as *mut Session,
+            session: self as *mut Session<IO>,
         })
     }
 
-    pub fn open_exec(&mut self) -> SshResult<ChannelExec> {
+    pub fn open_exec(&mut self) -> SshResult<ChannelExec<IO>> {
         let channel = self.open_channel()?;
         channel.open_exec()
     }
 
-    pub fn open_shell(&mut self) -> SshResult<ChannelShell> {
+    pub fn open_shell(&mut self) -> SshResult<ChannelShell<IO>> {
         let channel = self.open_channel()?;
         channel.open_shell()
     }
 
-    pub fn open_scp(&mut self) -> SshResult<ChannelScp> {
+    pub fn open_scp(&mut self) -> SshResult<ChannelScp<IO>> {
         let channel = self.open_channel()?;
         channel.open_scp()
     }
 }
 
-impl Session {
+impl<IO> Session<IO>
+where
+    IO: Read + Write,
+{
     // 本地请求远程打开通道
     fn send_open_channel(&mut self, client_channel_no: u32) -> SshResult<()> {
         let mut data = Data::new();

--- a/src/session_auth.rs
+++ b/src/session_auth.rs
@@ -5,9 +5,15 @@ use crate::h::H;
 use crate::key_pair::{KeyPair, KeyPairType};
 use crate::user_info::UserInfo;
 use crate::{Session, SshError, SshResult};
-use std::path::Path;
+use std::{
+    io::{Read, Write},
+    path::Path,
+};
 
-impl Session {
+impl<IO> Session<IO>
+where
+    IO: Read + Write,
+{
     fn get_user_info(&self) -> SshResult<&UserInfo> {
         if self.user_info.is_none() {
             return Err(SshError::from("user info is none."));

--- a/src/session_auth.rs
+++ b/src/session_auth.rs
@@ -10,9 +10,9 @@ use std::{
     path::Path,
 };
 
-impl<IO> Session<IO>
+impl<S> Session<S>
 where
-    IO: Read + Write,
+    S: Read + Write,
 {
     fn get_user_info(&self) -> SshResult<&UserInfo> {
         if self.user_info.is_none() {

--- a/src/window_size.rs
+++ b/src/window_size.rs
@@ -51,13 +51,13 @@ impl WindowSize {
 }
 
 impl WindowSize {
-    pub(crate) fn process_remote_window_size<IO>(
+    pub(crate) fn process_remote_window_size<S>(
         &mut self,
         data: &[u8],
-        client: &mut Client<IO>,
+        client: &mut Client<S>,
     ) -> SshResult<()>
     where
-        IO: Read + Write,
+        S: Read + Write,
     {
         let size = match self.get_size(data) {
             None => return Ok(()),
@@ -77,9 +77,9 @@ impl WindowSize {
         self.remote_window_size += rws;
     }
 
-    pub(crate) fn read_window_size<IO>(&mut self, client: &mut Client<IO>) -> SshResult<()>
+    pub(crate) fn read_window_size<S>(&mut self, client: &mut Client<S>) -> SshResult<()>
     where
-        IO: Read + Write,
+        S: Read + Write,
     {
         let results = client.read()?;
         if results.is_empty() {
@@ -100,13 +100,13 @@ impl WindowSize {
 }
 
 impl WindowSize {
-    pub(crate) fn process_local_window_size<IO>(
+    pub(crate) fn process_local_window_size<S>(
         &mut self,
         data: &[u8],
-        client: &mut Client<IO>,
+        client: &mut Client<S>,
     ) -> SshResult<()>
     where
-        IO: Read + Write,
+        S: Read + Write,
     {
         let size = match self.get_size(data) {
             None => return Ok(()),

--- a/src/window_size.rs
+++ b/src/window_size.rs
@@ -1,3 +1,5 @@
+use std::io::{Read, Write};
+
 use crate::client::Client;
 use crate::constant::size::LOCAL_WINDOW_SIZE;
 use crate::constant::ssh_msg_code;
@@ -49,11 +51,14 @@ impl WindowSize {
 }
 
 impl WindowSize {
-    pub(crate) fn process_remote_window_size(
+    pub(crate) fn process_remote_window_size<IO>(
         &mut self,
         data: &[u8],
-        client: &mut Client,
-    ) -> SshResult<()> {
+        client: &mut Client<IO>,
+    ) -> SshResult<()>
+    where
+        IO: Read + Write,
+    {
         let size = match self.get_size(data) {
             None => return Ok(()),
             Some(size) => size,
@@ -72,7 +77,10 @@ impl WindowSize {
         self.remote_window_size += rws;
     }
 
-    pub(crate) fn read_window_size(&mut self, client: &mut Client) -> SshResult<()> {
+    pub(crate) fn read_window_size<IO>(&mut self, client: &mut Client<IO>) -> SshResult<()>
+    where
+        IO: Read + Write,
+    {
         let results = client.read()?;
         if results.is_empty() {
             return Ok(());
@@ -92,11 +100,14 @@ impl WindowSize {
 }
 
 impl WindowSize {
-    pub(crate) fn process_local_window_size(
+    pub(crate) fn process_local_window_size<IO>(
         &mut self,
         data: &[u8],
-        client: &mut Client,
-    ) -> SshResult<()> {
+        client: &mut Client<IO>,
+    ) -> SshResult<()>
+    where
+        IO: Read + Write,
+    {
         let size = match self.get_size(data) {
             None => return Ok(()),
             Some(size) => size,


### PR DESCRIPTION
The main commit is the [first one](https://github.com/1148118271/ssh-rs/commit/d972dd405e8dd60cd9d92c20a7e4b50f868733ac)
It adds a generic type to the ssh client, decoupling the structure from TcpStream to IO: Read + Write.
This allows the user to connect to the ssh server using different methods (e.g. WebSocket or some other proxies).
POC at [here](https://github.com/HsuJv/ssh-rs/blob/generic_world/examples/bio/src/main.rs) which works fine.

In order not to break the compatibility of the existing APIs, a new API `connect_bio` has been added which asks the user to provide its buffered input/output objects. Whereas the type-specific bindings for TcpStream were always established in the old `connect` API.

```Rust
impl Session<TcpStream> {
    pub fn connect<A>(&mut self, addr: A) -> SshResult<()>
    where
        A: ToSocketAddrs,
    {
        if self.user_info.is_none() {
            return Err(SshError::from("user info is none."));
        }
        // 建立通道
        let tcp = TcpStream::connect(addr)?;
        // default nonblocking
        tcp.set_nonblocking(true).unwrap();

        log::info!("session opened.");
        self.connect_bio(tcp)
    }
}


impl<IO> Session<IO>
where
    IO: Read + Write,
{
    pub fn connect_bio(&mut self, stream: IO) -> SshResult<()> {
        if self.user_info.is_none() {
            return Err(SshError::from("user info is none."));
        }
        // 建立通道
        self.client = Some(Client::<IO>::connect(
            stream,
            self.timeout_sec,
            self.user_info.clone().unwrap(),
        )?);
        log::info!("session opened.");
        self.post_connect()
    }
}
```

All the old examples work fine.
Add a new [example](https://github.com/HsuJv/ssh-rs/blob/generic_world/examples/bio/src/main.rs) to show how bio works.