### PR TITLE
Use sha2-256 instead of sha1 to generate host key signature [RFC 8332]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/1148118271/ssh-rs"
 log = "0.4"
 rand = "0.8"
 # the crate rsa has removed the internal hash implement from 0.7.0
-sha1  = { version = "0.10.5", default-features = false, features = ["oid"]}
+sha2  = { version = "0.10.6", default-features = false, features = ["oid"]}
 rsa = "^0.7"
 aes = { version = "0.7", features = ["ctr"] }
 ring = "0.16.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,13 @@ repository = "https://github.com/1148118271/ssh-rs"
 [dependencies]
 log = "0.4"
 rand = "0.8"
-rsa = "0.5"
+# the crate rsa has removed the internal hash implement from 0.7.0
+sha1  = { version = "0.10.5", default-features = false, features = ["oid"]}
+rsa = "^0.7"
 aes = { version = "0.7", features = ["ctr"] }
 ring = "0.16.20"
 filetime = "0.2"
-ssh-key = "0.4.2"
+ssh-key = "^0.5"
 
 # async
 # [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/algorithm/public_key/rsa.rs
+++ b/src/algorithm/public_key/rsa.rs
@@ -20,9 +20,9 @@ impl PubK for Rsa {
         let e = rsa::BigUint::from_bytes_be(data.get_u8s().as_slice());
         let n = rsa::BigUint::from_bytes_be(data.get_u8s().as_slice());
         let public_key = rsa::RsaPublicKey::new(n, e).unwrap();
-        let scheme = rsa::PaddingScheme::new_pkcs1v15_sign::<sha1::Sha1>();
+        let scheme = rsa::PaddingScheme::new_pkcs1v15_sign::<sha2::Sha256>();
 
-        let digest = ring::digest::digest(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY, message);
+        let digest = ring::digest::digest(&ring::digest::SHA256, message);
         let msg = digest.as_ref();
 
         Ok(public_key.verify(scheme, msg, sig).is_ok())

--- a/src/algorithm/public_key/rsa.rs
+++ b/src/algorithm/public_key/rsa.rs
@@ -20,9 +20,7 @@ impl PubK for Rsa {
         let e = rsa::BigUint::from_bytes_be(data.get_u8s().as_slice());
         let n = rsa::BigUint::from_bytes_be(data.get_u8s().as_slice());
         let public_key = rsa::RsaPublicKey::new(n, e).unwrap();
-        let scheme = rsa::PaddingScheme::PKCS1v15Sign {
-            hash: Some(rsa::Hash::SHA1),
-        };
+        let scheme = rsa::PaddingScheme::new_pkcs1v15_sign::<sha1::Sha1>();
 
         let digest = ring::digest::digest(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY, message);
         let msg = digest.as_ref();

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,7 +135,7 @@ impl AlgorithmConfig {
         );
         match public_key_algorithm.as_str() {
             algorithms::PUBLIC_KEY_ED25519 => Ok(Box::new(Ed25519::new())),
-            algorithms::PUBLIC_KEY_RSA => Ok(Box::new(Rsa::new())),
+            algorithms::PUBLIC_KEY_RSA_256 => Ok(Box::new(Rsa::new())),
             _ => {
                 log::error!(
                     "description the signature algorithm fails to match, \
@@ -275,7 +275,7 @@ impl PublicKeyAlgorithm {
     pub fn get_client() -> Self {
         PublicKeyAlgorithm(vec![
             algorithms::PUBLIC_KEY_ED25519.to_string(),
-            algorithms::PUBLIC_KEY_RSA.to_string(),
+            algorithms::PUBLIC_KEY_RSA_256.to_string(),
         ])
     }
 }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,5 +1,5 @@
 /// 客户端版本
-pub const CLIENT_VERSION: &str = "SSH-2.0-SSH_RS-0.2.1";
+pub const CLIENT_VERSION: &str = "SSH-2.0-SSH_RS-0.2.2";
 
 /// ssh通讯时用到的常量字符串
 #[allow(dead_code)]

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -152,6 +152,8 @@ pub mod algorithms {
     /// 非对称签名算法
     pub const PUBLIC_KEY_ED25519: &str = "ssh-ed25519";
     pub const PUBLIC_KEY_RSA: &str = "ssh-rsa";
+    pub const PUBLIC_KEY_RSA_256: &str = "rsa-sha2-256";
+    pub const PUBLIC_KEY_RSA_512: &str = "rsa-sha2-512";
 
     /// 对称加密算法
     pub const ENCRYPTION_CHACHA20_POLY1305_OPENSSH: &str = "chacha20-poly1305@openssh.com";

--- a/src/key_pair.rs
+++ b/src/key_pair.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 #[derive(Clone, Default)]
 pub struct KeyPair {
     pub(crate) private_key: String,
-    pub(crate) key_type: String,
+    pub(crate) key_type: KeyPairType,
     pub(crate) blob: Vec<u8>,
 }
 
@@ -31,7 +31,6 @@ impl KeyPair {
     }
 
     pub fn from_str(key_str: &str, key_type: KeyPairType) -> SshResult<Self> {
-        let key_type_str = KeyPairType::get_string(key_type);
         let rprk = match rsa::RsaPrivateKey::from_pkcs1_pem(key_str) {
             Ok(e) => e,
             Err(e) => return Err(SshError::from(e.to_string())),
@@ -40,13 +39,13 @@ impl KeyPair {
         let es = rpuk.e().to_bytes_be();
         let ns = rpuk.n().to_bytes_be();
         let mut blob = Data::new();
-        blob.put_str(key_type_str);
+        blob.put_str(key_type.as_str());
         blob.put_mpint(&es);
         blob.put_mpint(&ns);
         let blob = blob.to_vec();
         let pair = KeyPair {
             private_key: key_str.to_string(),
-            key_type: key_type_str.to_string(),
+            key_type,
             blob,
         };
         Ok(pair)
@@ -61,8 +60,8 @@ impl KeyPair {
         let mut sd = Data::new();
         sd.put_u8s(session_id.as_slice());
         sd.extend_from_slice(buf);
-        let scheme = rsa::PaddingScheme::new_pkcs1v15_sign::<sha1::Sha1>();
-        let digest = ring::digest::digest(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY, sd.as_slice());
+        let scheme = rsa::PaddingScheme::new_pkcs1v15_sign::<sha2::Sha256>();
+        let digest = ring::digest::digest(&ring::digest::SHA256, sd.as_slice());
         let msg = digest.as_ref();
 
         let rprk = rsa::RsaPrivateKey::from_pkcs1_pem(self.private_key.as_str()).unwrap();
@@ -75,14 +74,25 @@ impl KeyPair {
     }
 }
 
+#[derive(Clone)]
 pub enum KeyPairType {
     SshRsa,
 }
 
+impl Default for KeyPairType {
+    fn default() -> Self {
+        KeyPairType::SshRsa
+    }
+}
+
 impl KeyPairType {
-    pub(crate) fn get_string<'a>(key_type: KeyPairType) -> &'a str {
-        match key_type {
-            KeyPairType::SshRsa => "ssh-rsa",
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            // use to rsa-sha2-256 by default according to
+            // https://www.rfc-editor.org/rfc/rfc8332#section-3
+            // My todo:
+            //    Add an API to support old server that only allows ssh-rsa
+            KeyPairType::SshRsa => crate::constant::algorithms::PUBLIC_KEY_RSA_256,
         }
     }
 }

--- a/src/key_pair.rs
+++ b/src/key_pair.rs
@@ -3,7 +3,7 @@ use crate::algorithm::hash::HashType;
 use crate::data::Data;
 use crate::h::H;
 use crate::{SshError, SshResult};
-use rsa::pkcs1::FromRsaPrivateKey;
+use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::PublicKeyParts;
 use std::fs::File;
 use std::io::Read;
@@ -61,9 +61,7 @@ impl KeyPair {
         let mut sd = Data::new();
         sd.put_u8s(session_id.as_slice());
         sd.extend_from_slice(buf);
-        let scheme = rsa::PaddingScheme::PKCS1v15Sign {
-            hash: Some(rsa::Hash::SHA1),
-        };
+        let scheme = rsa::PaddingScheme::new_pkcs1v15_sign::<sha1::Sha1>();
         let digest = ring::digest::digest(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY, sd.as_slice());
         let msg = digest.as_ref();
 


### PR DESCRIPTION
The OpenSSH has disabled ssh-rsa since version 8.8/8.8p1,
(See https://www.openssh.com/releasenotes.html)
SSH-RSA uses sha1 hash for public key verification which is confirmed cryptographically broken. It's reasonable to upgrade the hash algorithm to sha2-256 as recommended in [RFC 8332](https://www.rfc-editor.org/rfc/rfc8332#section-3)

But for compatibility reasons, we may add a new API which allows the user to connect to the old ssh servers that only allow ssh-rsa (SHA1). (TODO)

close #28 