### PR TITLE
Bugfix for #85

### DIFF
--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -58,7 +58,7 @@ impl SshVersion {
         S: Read,
     {
         let buf = read_version(stream, timeout)?;
-        if &buf[0..4] != SSH_MAGIC {
+        if buf.len() < 4 || &buf[0..4] != SSH_MAGIC {
             error!("SSH version magic doesn't match");
             error!("Probably not an ssh server");
         }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -50,14 +50,15 @@ where
             .connect(),
             SessionState::Version(mut config, mut stream) => {
                 info!("start for version negotiation.");
+                // Send Client version
+                config.ver.send_our_version(&mut stream)?;
+
                 // Receive the server version
                 config
                     .ver
                     .read_server_version(&mut stream, config.timeout)?;
                 // Version validate
                 config.ver.validate()?;
-                // Send Client version
-                config.ver.send_our_version(&mut stream)?;
 
                 // from now on
                 // each step of the interaction is subject to the ssh constraints on the packet


### PR DESCRIPTION
The main changes are:
1. Do not panic when connecting to a non-ssh server.
2. Send our version string first after the connection setup  (https://www.rfc-editor.org/rfc/rfc4253#section-4.2)